### PR TITLE
Fixes build failure in the default npm run start flow

### DIFF
--- a/examples/image_bbox/completions/1.json
+++ b/examples/image_bbox/completions/1.json
@@ -1,0 +1,79 @@
+{
+    "completions": [
+        {
+            "id": "1001",
+            "lead_time": 15.053,
+            "result": [
+                {
+                    "from_name": "tag",
+                    "id": "Dx_aB91ISN",
+                    "source": "$image",
+                    "to_name": "img",
+                    "type": "rectanglelabels",
+                    "value": {
+                        "height": 10.458911419423693,
+                        "rectanglelabels": [
+                            "Moonwalker"
+                        ],
+                        "rotation": 0,
+                        "width": 12.4,
+                        "x": 50.8,
+                        "y": 5.869797225186766
+                    }
+                }
+            ]
+        }
+    ],
+    "data": {
+        "image": "https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg"
+    },
+    "id": 1,
+    "predictions": [
+        {
+            "created_ago": "3 hours",
+            "model_version": "model 1",
+            "result": [
+                {
+                    "from_name": "tag",
+                    "id": "t5sp3TyXPo",
+                    "source": "$image",
+                    "to_name": "img",
+                    "type": "rectanglelabels",
+                    "value": {
+                        "height": 11.612284069097889,
+                        "rectanglelabels": [
+                            "Moonwalker"
+                        ],
+                        "rotation": 0,
+                        "width": 39.6,
+                        "x": 13.2,
+                        "y": 34.702495201535505
+                    }
+                }
+            ]
+        },
+        {
+            "created_ago": "4 hours",
+            "model_version": "model 2",
+            "result": [
+                {
+                    "from_name": "tag",
+                    "id": "t5sp3TyXPo",
+                    "source": "$image",
+                    "to_name": "img",
+                    "type": "rectanglelabels",
+                    "value": {
+                        "height": 33.61228406909789,
+                        "rectanglelabels": [
+                            "Moonwalker"
+                        ],
+                        "rotation": 0,
+                        "width": 39.6,
+                        "x": 13.2,
+                        "y": 54.702495201535505
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/scripts/copy.sh
+++ b/scripts/copy.sh
@@ -1,2 +1,2 @@
-mkdir src/examples
+mkdir -p src/examples
 cp -r examples/* src/examples/

--- a/scripts/copy.sh
+++ b/scripts/copy.sh
@@ -1,1 +1,2 @@
+mkdir src/examples
 cp -r examples/* src/examples/


### PR DESCRIPTION
When building the project as per instructions in README.md one currently encounters two errors: 

1. 
 ```bash
> bash scripts/copy.sh
cp: target 'src/examples/' is not a directory 
``` 
Once fixed, one gets: 
2. 
```
Failed to compile

./src/examples/image_bbox/index.js
Module not found: Can't resolve './completions/1.json' in 'path/to/label-studio-frontend/src/examples/image_bbox' 
``` 
 
This PR fixes both issues by tweaking `scripts/copy.sh` and by adding the missing completion data