### PR TITLE
Added an ability to pan image when zoomed

### DIFF
--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -66,7 +66,18 @@ export default observer(
        */
       item.freezeHistory();
 
-      return item.onMouseMove(e);
+      const stage = item.stageRef;
+      const scale = stage.scaleX();
+
+      if (e.evt && (e.evt.buttons == 4 || (e.evt.buttons == 1 && e.evt.shiftKey)) && scale > 1) {
+        e.evt.preventDefault();
+        const newPos = { x: stage.x() + e.evt.movementX, y: stage.y() + e.evt.movementY };
+        item.setZoom(scale, newPos.x, newPos.y);
+        stage.position(newPos);
+        stage.batchDraw();
+      } else {
+        return item.onMouseMove(e);
+      }
     };
 
     /**


### PR DESCRIPTION
Hi!

We've got this project where we need to detect lots of small objects in a photo. We discovered Label Studio to be a great tool, with one downside: you can't pan the image while it's zoomed. We use zoom all the time and constantly zooming in and out is really unproductive. So I've added an ability to pan the image along with its polygons. When image is zoomed, it can be panned with Shift + Left mouse button, or with middle mouse button.