### PR TITLE
fillOpacity parameter

### DIFF
--- a/examples/image_bbox/config.xml
+++ b/examples/image_bbox/config.xml
@@ -1,6 +1,6 @@
 <View>
   <Image name="img" value="$image"></Image>
-  <RectangleLabels name="tag" toName="img" strokeWidth="5">
+  <RectangleLabels name="tag" toName="img" fillOpacity="0.5" strokeWidth="5">
     <Label value="Planet"></Label>
     <Label value="Moonwalker" background="blue"></Label>
   </RectangleLabels>

--- a/examples/image_bbox/config.xml
+++ b/examples/image_bbox/config.xml
@@ -1,6 +1,6 @@
 <View>
   <Image name="img" value="$image"></Image>
-  <RectangleLabels name="tag" toName="img">
+  <RectangleLabels name="tag" toName="img" strokeWidth="5">
     <Label value="Planet"></Label>
     <Label value="Moonwalker" background="blue"></Label>
   </RectangleLabels>

--- a/examples/image_ellipses/config.xml
+++ b/examples/image_ellipses/config.xml
@@ -1,8 +1,8 @@
 <View>
   <Image name="img" value="$image"></Image>
-  <EllipseLabels name="tag" toName="img" strokeWidth="3">
-    <Label value="Planet" background="yellow"  fillopacity="0.0"></Label>
-    <Label value="Moonwalker" background="red" fillopacity="0.2"></Label>
+  <EllipseLabels name="tag" toName="img" fillOpacity="0.5" strokeWidth="3">
+    <Label value="Planet" background="yellow"></Label>
+    <Label value="Moonwalker" background="red"></Label>
   </EllipseLabels>
   <Choices name="choice" toName="img">
     <Choice value="Space" />

--- a/examples/image_ellipses/config.xml
+++ b/examples/image_ellipses/config.xml
@@ -1,8 +1,8 @@
 <View>
   <Image name="img" value="$image"></Image>
-  <EllipseLabels name="tag" toName="img" canRotate="true">
-    <Label value="Planet"></Label>
-    <Label value="Moonwalker" background="blue"></Label>
+  <EllipseLabels name="tag" toName="img" strokeWidth="3">
+    <Label value="Planet" background="yellow"  fillopacity="0.0"></Label>
+    <Label value="Moonwalker" background="red" fillopacity="0.2"></Label>
   </EllipseLabels>
   <Choices name="choice" toName="img">
     <Choice value="Space" />

--- a/src/mixins/SelectedModel.js
+++ b/src/mixins/SelectedModel.js
@@ -6,6 +6,7 @@ const SelectedModelMixin = types
   .model()
   .views(self => ({
     get tiedChildren() {
+      console.log(Tree.filterChildrenOfType(self, self._child));
       return Tree.filterChildrenOfType(self, self._child);
     },
 
@@ -25,6 +26,12 @@ const SelectedModelMixin = types
       // return first selected label color
       const sel = self.tiedChildren.find(c => c.selected === true);
       return sel && sel.background;
+    },
+
+    getFillOpacity() {
+      const sel = self.tiedChildren.find(c => c.selected === true);
+      const fillOpacityParsed = Number(sel.fillopacity);
+      return fillOpacityParsed;
     },
 
     findLabel(value) {

--- a/src/mixins/SelectedModel.js
+++ b/src/mixins/SelectedModel.js
@@ -28,12 +28,6 @@ const SelectedModelMixin = types
       return sel && sel.background;
     },
 
-    getFillOpacity() {
-      const sel = self.tiedChildren.find(c => c.selected === true);
-      const fillOpacityParsed = Number(sel.fillopacity);
-      return fillOpacityParsed;
-    },
-
     findLabel(value) {
       return self.tiedChildren.find(c => c.alias === value || c.value === value);
     },

--- a/src/regions/EllipseRegion.js
+++ b/src/regions/EllipseRegion.js
@@ -2,8 +2,6 @@ import React, { Fragment } from "react";
 import { Ellipse } from "react-konva";
 import { observer, inject } from "mobx-react";
 import { types, getParentOfType, getParent, getRoot } from "mobx-state-tree";
-// import { sin, cos, pow, abs, unit } from Math;
-
 import WithStatesMixin from "../mixins/WithStates";
 import Constants from "../core/Constants";
 import DisabledMixin from "../mixins/Normalization";
@@ -54,6 +52,7 @@ const Model = types
 
     fill: types.optional(types.boolean, true),
     fillcolor: types.optional(types.string, Constants.FILL_COLOR),
+    fillOpacity: types.optional(types.number, 0.3),
 
     strokeColor: types.optional(types.string, Constants.STROKE_COLOR),
     strokeWidth: types.optional(types.number, Constants.STROKE_WIDTH),
@@ -99,6 +98,7 @@ const Model = types
     updateAppearenceFromState() {
       const stroke = self.states[0].getSelectedColor();
       self.strokeColor = stroke;
+      self.fillOpacity = self.states[0].getFillOpacity();
       self.fillcolor = stroke;
     },
 
@@ -241,7 +241,7 @@ const HtxEllipseView = ({ store, item }) => {
         y={item.y}
         radiusX={item.radiusX}
         radiusY={item.radiusY}
-        fill={item.fill ? Utils.Colors.convertToRGBA(item.fillcolor, 0.4) : null}
+        fill={item.fill ? Utils.Colors.convertToRGBA(item.fillcolor, item.fillOpacity) : null}
         stroke={strokeColor}
         strokeWidth={strokeWidth}
         strokeScaleEnabled={false}

--- a/src/regions/EllipseRegion.js
+++ b/src/regions/EllipseRegion.js
@@ -52,7 +52,7 @@ const Model = types
 
     fill: types.optional(types.boolean, true),
     fillcolor: types.optional(types.string, Constants.FILL_COLOR),
-    fillOpacity: types.optional(types.number, 0.3),
+    fillOpacity: types.optional(types.number, 0.6),
 
     strokeColor: types.optional(types.string, Constants.STROKE_COLOR),
     strokeWidth: types.optional(types.number, Constants.STROKE_WIDTH),
@@ -98,7 +98,6 @@ const Model = types
     updateAppearenceFromState() {
       const stroke = self.states[0].getSelectedColor();
       self.strokeColor = stroke;
-      self.fillOpacity = self.states[0].getFillOpacity();
       self.fillcolor = stroke;
     },
 
@@ -230,10 +229,13 @@ const EllipseRegionModel = types.compose(
 
 const HtxEllipseView = ({ store, item }) => {
   let { strokeColor, strokeWidth } = item;
+  console.log(item);
+  console.log("EllipseRegion strokeWidth: " + strokeWidth);
   if (item.highlighted) {
     strokeColor = Constants.HIGHLIGHTED_STROKE_COLOR;
     strokeWidth = Constants.HIGHLIGHTED_STROKE_WIDTH;
   }
+  console.log("fillOpacity is: " + item.fillOpacity);
   return (
     <Fragment>
       <Ellipse

--- a/src/regions/RectRegion.js
+++ b/src/regions/RectRegion.js
@@ -50,7 +50,7 @@ const Model = types
 
     fill: types.optional(types.boolean, true),
     fillcolor: types.optional(types.string, Constants.FILL_COLOR),
-    fillOpacity: types.optional(types.number, 0.3),
+    fillOpacity: types.optional(types.number, 0.6),
 
     strokeColor: types.optional(types.string, Constants.STROKE_COLOR),
     strokeWidth: types.optional(types.number, Constants.STROKE_WIDTH),

--- a/src/regions/RectRegion.js
+++ b/src/regions/RectRegion.js
@@ -50,6 +50,7 @@ const Model = types
 
     fill: types.optional(types.boolean, true),
     fillcolor: types.optional(types.string, Constants.FILL_COLOR),
+    fillOpacity: types.optional(types.number, 0.3),
 
     strokeColor: types.optional(types.string, Constants.STROKE_COLOR),
     strokeWidth: types.optional(types.number, Constants.STROKE_WIDTH),
@@ -229,7 +230,7 @@ const HtxRectangleView = ({ store, item }) => {
         y={item.y}
         width={item.width}
         height={item.height}
-        fill={item.fill ? Utils.Colors.convertToRGBA(item.fillcolor, 0.4) : null}
+        fill={item.fill ? Utils.Colors.convertToRGBA(item.fillcolor, item.fillOpacity) : null}
         stroke={strokeColor}
         strokeWidth={strokeWidth}
         strokeScaleEnabled={false}

--- a/src/tags/control/Ellipse.js
+++ b/src/tags/control/Ellipse.js
@@ -29,6 +29,7 @@ const TagAttrs = types.model({
 
   strokewidth: types.optional(types.string, "1"),
   strokecolor: types.optional(types.string, "#f48a42"),
+  fillopacity: types.optional(types.string, "0.6"),
 
   canrotate: types.optional(types.boolean, true),
 });

--- a/src/tags/control/Ellipse.js
+++ b/src/tags/control/Ellipse.js
@@ -27,7 +27,7 @@ const TagAttrs = types.model({
   opacity: types.optional(types.string, "0.6"),
   fillcolor: types.maybeNull(types.string),
 
-  strokewidth: types.optional(types.number, 1),
+  strokewidth: types.optional(types.string, "1"),
   strokecolor: types.optional(types.string, "#f48a42"),
 
   canrotate: types.optional(types.boolean, true),

--- a/src/tags/control/EllipseLabels.js
+++ b/src/tags/control/EllipseLabels.js
@@ -39,7 +39,7 @@ const ModelAttrs = types.model("EllipseLabelsModel", {
   id: types.optional(types.identifier, guidGenerator),
   pid: types.optional(types.string, guidGenerator),
   type: "ellipselabels",
-  children: Types.unionArray(["labels", "label", "choice"]),
+  children: Types.unionArray(["label", "header", "view", "hypertext"]),
 });
 
 const Model = LabelMixin.props({ _type: "ellipselabels" }).views(self => ({
@@ -48,7 +48,14 @@ const Model = LabelMixin.props({ _type: "ellipselabels" }).views(self => ({
   },
 }));
 
-const Composition = types.compose(LabelsModel, ModelAttrs, EllipseModel, TagAttrs, Model, SelectedModelMixin);
+const Composition = types.compose(
+  LabelsModel,
+  ModelAttrs,
+  EllipseModel,
+  TagAttrs,
+  Model,
+  SelectedModelMixin.props({ _child: "LabelModel" }),
+);
 
 const EllipseLabelsModel = types.compose("EllipseLabelsModel", Composition);
 

--- a/src/tags/control/Label.js
+++ b/src/tags/control/Label.js
@@ -45,7 +45,6 @@ const TagAttrs = types.model({
   size: types.optional(types.string, "medium"),
   background: types.optional(types.string, Constants.LABEL_BACKGROUND),
   selectedcolor: types.optional(types.string, "white"),
-  fillopacity: types.optional(types.string, "0.2"),
 });
 
 const Model = types

--- a/src/tags/control/Label.js
+++ b/src/tags/control/Label.js
@@ -45,6 +45,7 @@ const TagAttrs = types.model({
   size: types.optional(types.string, "medium"),
   background: types.optional(types.string, Constants.LABEL_BACKGROUND),
   selectedcolor: types.optional(types.string, "white"),
+  fillopacity: types.optional(types.string, "0.2"),
 });
 
 const Model = types

--- a/src/tools/Ellipse.js
+++ b/src/tools/Ellipse.js
@@ -57,6 +57,7 @@ const _Tool = types
         opacity: parseFloat(control.opacity),
         fillcolor: stroke || control.fillcolor,
         strokeWidth: Number(control.strokewidth),
+        fillOpacity: Number(control.fillopacity),
         strokeColor: stroke || control.strokecolor,
       });
 

--- a/src/tools/Ellipse.js
+++ b/src/tools/Ellipse.js
@@ -56,7 +56,7 @@ const _Tool = types
 
         opacity: parseFloat(control.opacity),
         fillcolor: stroke || control.fillcolor,
-        strokeWidth: control.strokewidth,
+        strokeWidth: Number(control.strokewidth),
         strokeColor: stroke || control.strokecolor,
       });
 

--- a/src/tools/Rect.js
+++ b/src/tools/Rect.js
@@ -68,6 +68,7 @@ const _Tool = types
         opacity: parseFloat(control.opacity),
         fillcolor: stroke || control.fillcolor,
         strokeWidth: Number(control.strokewidth),
+        fillOpacity: Number(control.fillopacity),
         strokeColor: stroke || control.strokecolor,
       });
 

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -154,7 +154,7 @@ export function hexToRGBA(hex, opacity) {
 
   let a = 0.3;
 
-  if (opacity && typeof parseInt(opacity) === "number") {
+  if (typeof parseInt(opacity) === "number") {
     a = opacity;
   }
 


### PR DESCRIPTION
In accordance with my suggestion #30 I made this pull request.

I have successfully implemented this functionality for `RectangleLabels` and `EllipseLabels`. Fill with color for `PolygonLabels` seems to be different. So I decided to not implement it right now. Maybe a little bit later. 