### PR TITLE
Don't clear selection when no labels active

### DIFF
--- a/src/tags/object/HyperText.js
+++ b/src/tags/object/HyperText.js
@@ -193,14 +193,12 @@ class HyperTextPieceView extends Component {
   }
 
   onMouseUp(ev) {
-    var selectedRanges = this.captureDocumentSelection();
-
     const states = this.props.item.activeStates();
     if (!states || states.length === 0) return;
 
-    if (selectedRanges.length === 0) {
-      return;
-    }
+    var selectedRanges = this.captureDocumentSelection();
+
+    if (selectedRanges.length === 0) return;
 
     const htxRange = this.props.item.addRegion(selectedRanges[0]);
     const spans = htxRange.createSpans();

--- a/src/tags/object/Text.js
+++ b/src/tags/object/Text.js
@@ -376,11 +376,13 @@ class TextPieceView extends Component {
 
     if (!item.selectionenabled) return;
 
-    var selectedRanges = this.captureDocumentSelection();
-
     const states = item.activeStates();
 
-    if (!states || states.length === 0 || selectedRanges.length === 0) return;
+    if (!states || states.length === 0) return;
+
+    var selectedRanges = this.captureDocumentSelection();
+
+    if (selectedRanges.length === 0) return;
 
     ev.nativeEvent.doSelection = true;
 


### PR DESCRIPTION
Both for Text and HyperText leave the text selection untouched if there are no labels selected at this moment. This allows user to copy selected text.
Previously text selection was cleared immediately after mouse up, preventing user to interact with text.

Fixes heartexlabs/label-studio#265