### PR TITLE
Fix work with ranges for word granularity

### DIFF
--- a/src/env/development.js
+++ b/src/env/development.js
@@ -44,7 +44,7 @@ import { Pairwise } from "../examples/pairwise"; // eslint-disable-line no-unuse
  */
 // import { AllTypes } from "../examples/all_types"; // eslint-disable-line no-unused-vars
 
-const data = ImageBbox;
+const data = NamedEntity;
 
 /**
  * Get current config

--- a/src/tags/object/Text.js
+++ b/src/tags/object/Text.js
@@ -290,7 +290,7 @@ class TextPieceView extends Component {
 
       if (idx > 0) {
         const { node, len } = Utils.HTML.findIdxContainer(this.myRef, idx + 1);
-        r2.setEnd(node, len - 1);
+        r2.setEnd(node, len > 0 ? len - 1 : 0);
       }
     }
 
@@ -341,7 +341,7 @@ class TextPieceView extends Component {
         splitBoundaries(r);
 
         normedRange._range = r;
-        normedRange.text = selection.toString();
+        normedRange.text = r.toString();
 
         const ss = Utils.HTML.toGlobalOffset(self.myRef, r.startContainer, r.startOffset);
         const ee = Utils.HTML.toGlobalOffset(self.myRef, r.endContainer, r.endOffset);


### PR DESCRIPTION
* Don't break on some selections (possibly reaching the end of block)
* Always show selected text in regions list and in serialisation (sometimes it was blank)