### PR TITLE
localStorage and serviceWorker break sandboxed env

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 import { Provider } from "mobx-react";
 
 import "./assets/styles/global.scss";
-import * as serviceWorker from "./serviceWorker";
 import App from "./components/App/App";
 import AppStore from "./stores/AppStore";
 import ProductionEnvironment from "./env/production";
@@ -90,8 +89,3 @@ if (process.env.NODE_ENV === "production") {
     }
   };
 }
-
-// If you want your app to work offline and load faster, you can change
-// unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: http://bit.ly/CRA-PWA
-serviceWorker.unregister();

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -47,27 +47,31 @@ const SettingsModel = types
   }))
   .actions(self => ({
     afterCreate() {
-      const { localStorage } = window;
-
-      if (localStorage) {
-        const lsKey = "labelStudio:settings";
-
-        // load settings from the browser store
-        const lss = localStorage.getItem(lsKey);
-        if (lss) {
-          const lsp = JSON.parse(lss);
-          typeof lsp === "object" &&
-            lsp !== null &&
-            Object.keys(lsp).forEach(k => {
-              if (k in self) self[k] = lsp[k];
-            });
-        }
-
-        // capture changes and save it
-        onSnapshot(self, ss => {
-          localStorage.setItem(lsKey, JSON.stringify(ss));
-        });
+      // sandboxed environment may break even on check of this property
+      try {
+        const { localStorage } = window;
+        if (!localStorage) return;
+      } catch (e) {
+        return;
       }
+
+      const lsKey = "labelStudio:settings";
+
+      // load settings from the browser store
+      const lss = localStorage.getItem(lsKey);
+      if (lss) {
+        const lsp = JSON.parse(lss);
+        typeof lsp === "object" &&
+          lsp !== null &&
+          Object.keys(lsp).forEach(k => {
+            if (k in self) self[k] = lsp[k];
+          });
+      }
+
+      // capture changes and save it
+      onSnapshot(self, ss => {
+        localStorage.setItem(lsKey, JSON.stringify(ss));
+      });
     },
 
     //   toggleShowScore() {


### PR DESCRIPTION
On some sandboxed environments any access to such properties causes exception.
Settings can work with defaults and store data per session.
Service Workers aren't used anyway.