### PR TITLE
Bugfix for overlapping spans

### DIFF
--- a/src/mixins/SpanText.js
+++ b/src/mixins/SpanText.js
@@ -79,10 +79,12 @@ export default types
 
     addEventsToSpans(spans) {
       const addEvent = s => {
-        s.onmouseover = function() {
+        s.onmouseover = function(ev) {
           if (self.completion.relationMode) {
             self.toggleHighlight();
             s.style.cursor = Constants.RELATION_MODE_CURSOR;
+            // only one span should be highlighted
+            ev.stopPropagation();
           } else {
             s.style.cursor = Constants.POINTER_CURSOR;
           }
@@ -90,16 +92,23 @@ export default types
 
         s.onmouseout = function() {
           self.setHighlight(false);
-          s.style.cursor = Constants.DEFAULT_CURSOR;
+        };
+
+        s.onmousedown = function(ev) {
+          // if we click to already selected span (=== this)
+          // skip it to allow another span to be selected
+          if (self.parent._currentSpan !== this) {
+            ev.stopPropagation();
+            self.parent._currentSpan = this;
+          }
         };
 
         s.onclick = function(ev) {
-          if (ev.doSelection) return;
+          // set above in `onmousedown`, can be nulled when new region created
+          if (self.parent._currentSpan !== this) return;
+          // reset for the case we just created new relation
+          s.style.cursor = Constants.POINTER_CURSOR;
           self.onClickRegion();
-        };
-
-        s.mouseover = function() {
-          this.style.cursor = "pointer";
         };
 
         return false;

--- a/src/tags/object/HyperText.js
+++ b/src/tags/object/HyperText.js
@@ -195,14 +195,17 @@ class HyperTextPieceView extends Component {
   }
 
   onMouseUp(ev) {
-    const states = this.props.item.activeStates();
+    const item = this.props.item;
+    const states = item.activeStates();
     if (!states || states.length === 0) return;
 
     var selectedRanges = this.captureDocumentSelection();
 
     if (selectedRanges.length === 0) return;
 
-    const htxRange = this.props.item.addRegion(selectedRanges[0]);
+    item._currentSpan = null;
+
+    const htxRange = item.addRegion(selectedRanges[0]);
     if (htxRange) {
       const spans = htxRange.createSpans();
       htxRange.addEventsToSpans(spans);

--- a/src/tags/object/Text.js
+++ b/src/tags/object/Text.js
@@ -385,18 +385,16 @@ class TextPieceView extends Component {
 
   onMouseUp(ev) {
     const item = this.props.item;
-
     if (!item.selectionenabled) return;
 
     const states = item.activeStates();
-
     if (!states || states.length === 0) return;
 
     var selectedRanges = this.captureDocumentSelection();
-
     if (selectedRanges.length === 0) return;
 
-    ev.nativeEvent.doSelection = true;
+    // prevent overlapping spans from being selected right after this
+    item._currentSpan = null;
 
     const htxRange = item.addRegion(selectedRanges[0]);
     if (htxRange) {


### PR DESCRIPTION
Bug: when you create span finishing your selection over the another span, that span will be selected and the created one will have its label.
Improvement: you can switch between two overlapping spans just by clicking repeatedly at the same point (not for 3+)