### PR TITLE
Don't allow shapes to move/scale beyond the Image borders

### DIFF
--- a/src/components/ImageTransformer/ImageTransformer.js
+++ b/src/components/ImageTransformer/ImageTransformer.js
@@ -47,6 +47,7 @@ export default class TransformerComponent extends Component {
     return (
       <Transformer
         resizeEnabled={true}
+        ignoreStroke={true}
         keepRatio={false}
         rotateEnabled={this.props.rotateEnabled}
         borderDash={[3, 1]}

--- a/src/components/ImageTransformer/ImageTransformer.js
+++ b/src/components/ImageTransformer/ImageTransformer.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { Transformer } from "react-konva";
+import { MIN_SIZE } from "../../tools/Base";
 
 export default class TransformerComponent extends Component {
   componentDidMount() {
@@ -41,6 +42,30 @@ export default class TransformerComponent extends Component {
     this.transformer.getLayer().batchDraw();
   }
 
+  constrainSizes = (oldBox, newBox) => {
+    let { x, y, width, height, rotation } = newBox;
+    let { stageHeight, stageWidth } = this.props.item;
+
+    width = Math.max(MIN_SIZE.X, newBox.width);
+    height = Math.max(MIN_SIZE.Y, newBox.height);
+
+    if (x < 0) {
+      width = width + x;
+      x = 0;
+    } else if (x + width > stageWidth) {
+      width = stageWidth - x;
+    }
+
+    if (y < 0) {
+      height = height + y;
+      y = 0;
+    } else if (y + height > stageHeight) {
+      height = stageHeight - y;
+    }
+
+    return { x, y, width, height, rotation };
+  };
+
   render() {
     if (!this.props.selectedShape.supportsTransform) return null;
 
@@ -51,12 +76,7 @@ export default class TransformerComponent extends Component {
         keepRatio={false}
         rotateEnabled={this.props.rotateEnabled}
         borderDash={[3, 1]}
-        // borderStroke={"red"}
-        boundBoxFunc={(oldBox, newBox) => {
-          newBox.width = Math.max(3, newBox.width);
-          newBox.height = Math.max(3, newBox.height);
-          return newBox;
-        }}
+        boundBoxFunc={this.constrainSizes}
         anchorSize={8}
         ref={node => {
           this.transformer = node;

--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -345,13 +345,7 @@ export default observer(
             {item.regions
               .filter(shape => shape.type === "brushregion")
               .map(shape => (
-                <Layer
-                  ref={ref => {
-                    shape.setLayerRef(ref);
-                  }}
-                  name={"brushLayer-" + shape.id}
-                  id={shape.id}
-                >
+                <Layer name={"brushLayer-" + shape.id} id={shape.id}>
                   {Tree.renderItem(shape)}
                 </Layer>
               ))}

--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -11,11 +11,6 @@ import styles from "./ImageView.module.scss";
 
 export default observer(
   class ImageView extends Component {
-    constructor(props) {
-      super(props);
-
-      this.onResize = this.onResize.bind(this);
-    }
     /**
      * Handler of click on Image
      */
@@ -198,9 +193,9 @@ export default observer(
       );
     }
 
-    onResize() {
+    onResize = () => {
       this.props.item.onResize(this.container.offsetWidth, this.container.offsetHeight, true);
-    }
+    };
 
     componentDidMount() {
       window.addEventListener("resize", this.onResize);
@@ -301,23 +296,19 @@ export default observer(
             onWheel={item.zoom ? this.handleZoom : () => {}}
           >
             {item.grid && item.sizeUpdated && <ImageGrid item={item} />}
-            {item.regions.map(shape => {
-              let brushShape;
-              if (shape.type === "brushregion") {
-                brushShape = (
-                  <Layer
-                    ref={ref => {
-                      shape.setLayerRef(ref);
-                    }}
-                    name={"brushLayer-" + shape.id}
-                    id={shape.id}
-                  >
-                    {Tree.renderItem(shape)}
-                  </Layer>
-                );
-              }
-              return brushShape;
-            })}
+            {item.regions
+              .filter(shape => shape.type === "brushregion")
+              .map(shape => (
+                <Layer
+                  ref={ref => {
+                    shape.setLayerRef(ref);
+                  }}
+                  name={"brushLayer-" + shape.id}
+                  id={shape.id}
+                >
+                  {Tree.renderItem(shape)}
+                </Layer>
+              ))}
             <Layer>
               {item.regions.filter(s => s.type !== "brushregion").map(s => Tree.renderItem(s))}
               {item.activeShape && Tree.renderItem(item.activeShape)}

--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -356,7 +356,7 @@ export default observer(
               {item.activeShape && Tree.renderItem(item.activeShape)}
 
               {item.selectedShape && item.selectedShape.editable && (
-                <ImageTransformer rotateEnabled={cb && cb.canrotate} selectedShape={item.selectedShape} />
+                <ImageTransformer item={item} rotateEnabled={cb && cb.canrotate} selectedShape={item.selectedShape} />
               )}
             </Layer>
           </Stage>

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import ProductionEnvironment from "./env/production";
 if (process.env.NODE_ENV === "production") {
   const environment = ProductionEnvironment;
 
-  window.LabelStudio = (element, options) => {
+  window.LabelStudio = function(element, options) {
     let params = options;
 
     if (params && params.task) {
@@ -40,7 +40,7 @@ if (process.env.NODE_ENV === "production") {
 } else {
   const environment = require("./env/development").default;
 
-  window.LabelStudio = (element, options) => {
+  window.LabelStudio = function(element, options) {
     let params = options;
 
     // this is a way to initialize one of the examples from the src/examples section

--- a/src/mixins/DrawingTool.js
+++ b/src/mixins/DrawingTool.js
@@ -1,0 +1,22 @@
+import { types } from "mobx-state-tree";
+
+import Utils from "../utils";
+import lodash from "../utils/lodash";
+
+const DrawingTool = types.model("DrawingTool").actions(self => ({
+  updateDraw: lodash.throttle(function(x, y) {
+    const shape = self.getActiveShape;
+    const { stageWidth, stageHeight } = self.obj;
+
+    let { x1, y1, x2, y2 } = Utils.Image.reverseCoordinates({ x: shape.startX, y: shape.startY }, { x, y });
+
+    x1 = Math.max(0, x1);
+    y1 = Math.max(0, y1);
+    x2 = Math.min(stageWidth, x2);
+    y2 = Math.min(stageHeight, y2);
+
+    shape.setPosition(x1, y1, x2 - x1, y2 - y1, shape.rotation);
+  }, 48), // 4 frames, optimized enough and not laggy yet
+}));
+
+export { DrawingTool };

--- a/src/regions/BrushRegion.js
+++ b/src/regions/BrushRegion.js
@@ -149,10 +149,6 @@ const Model = types
     //   self.eraserpoints = [...self.eraserpoints, x, y];
     // },
 
-    setLayerRef(ref) {
-      self.layerRef = ref;
-    },
-
     setScale(x, y) {
       self.scaleX = x;
       self.scaleY = y;

--- a/src/regions/EllipseRegion.js
+++ b/src/regions/EllipseRegion.js
@@ -278,22 +278,19 @@ const HtxEllipseView = ({ store, item }) => {
           let { x, y } = pos;
           let { stageHeight, stageWidth } = getParent(item, 2);
 
-          if (x <= 0) {
+          if (x < 0) {
             x = 0;
-          } else if (x + item.width >= stageWidth) {
-            x = stageWidth - item.width;
+          } else if (x > stageWidth) {
+            x = stageWidth;
           }
 
           if (y < 0) {
             y = 0;
-          } else if (y + item.height >= stageHeight) {
-            y = stageHeight - item.height;
+          } else if (y > stageHeight) {
+            y = stageHeight;
           }
 
-          return {
-            x: x,
-            y: y,
-          };
+          return { x, y };
         }}
         onMouseOver={e => {
           const stage = item.parent.stageRef;

--- a/src/tags/object/Image.js
+++ b/src/tags/object/Image.js
@@ -346,13 +346,8 @@ const Model = types
       shape.selectRegion();
     },
 
-    getEvCoords(ev) {
-      if (!ev.evt) return [];
-
-      const x = (ev.evt.offsetX - self.zoomingPositionX) / self.zoomScale;
-      const y = (ev.evt.offsetY - self.zoomingPositionY) / self.zoomScale;
-
-      return [x, y];
+    fixZoomedCoords([x, y]) {
+      return [(x - self.zoomingPositionX) / self.zoomScale, (y - self.zoomingPositionY) / self.zoomScale];
     },
 
     /**
@@ -368,23 +363,8 @@ const Model = types
       });
     },
 
-    onImageClick(ev) {
-      const coords = self.getEvCoords(ev);
-      self.getToolsManager().event("click", ev, ...coords);
-    },
-
-    onMouseDown(ev) {
-      const coords = self.getEvCoords(ev);
-      self.getToolsManager().event("mousedown", ev, ...coords);
-    },
-
-    onMouseMove(ev) {
-      const coords = self.getEvCoords(ev);
-      self.getToolsManager().event("mousemove", ev, ...coords);
-    },
-
-    onMouseUp(ev) {
-      self.getToolsManager().event("mouseup", ev);
+    event(name, ev, ...coords) {
+      self.getToolsManager().event(name, ev, ...self.fixZoomedCoords(coords));
     },
 
     /**

--- a/src/tools/Base.js
+++ b/src/tools/Base.js
@@ -2,4 +2,6 @@ import { types } from "mobx-state-tree";
 
 const BaseTool = types.model("BaseTool", {}).actions(self => ({}));
 
+export const MIN_SIZE = { X: 3, Y: 3 };
+
 export default BaseTool;

--- a/src/tools/Ellipse.js
+++ b/src/tools/Ellipse.js
@@ -1,11 +1,10 @@
 import { types, destroy } from "mobx-state-tree";
 
-import Utils from "../utils";
 import BaseTool, { MIN_SIZE } from "./Base";
 import ToolMixin from "../mixins/Tool";
 import { EllipseRegionModel } from "../regions/EllipseRegion";
 import { guidGenerator, restoreNewsnapshot } from "../core/Helpers";
-import lodash from "../utils/lodash";
+import { DrawingTool } from "../mixins/DrawingTool";
 
 const _Tool = types
   .model({
@@ -35,14 +34,6 @@ const _Tool = types
 
       return ellipse;
     },
-
-    updateDraw: lodash.throttle(function(x, y) {
-      const shape = self.getActiveShape;
-
-      const { x1, y1, x2, y2 } = Utils.Image.reverseCoordinates({ x: shape.startX, y: shape.startY }, { x: x, y: y });
-
-      shape.setPosition(x1, y1, x2 - x1, y2 - y1, shape.rotation);
-    }, 48), // 4 frames, optimized enough and not laggy yet
 
     mousedownEv(ev, [x, y]) {
       if (self.control.type === "ellipselabels" && !self.control.isSelected) return;
@@ -88,6 +79,6 @@ const _Tool = types
     },
   }));
 
-const Ellipse = types.compose(ToolMixin, BaseTool, _Tool);
+const Ellipse = types.compose(ToolMixin, BaseTool, DrawingTool, _Tool);
 
 export { Ellipse };

--- a/src/tools/Rect.js
+++ b/src/tools/Rect.js
@@ -1,12 +1,11 @@
 import { types, destroy } from "mobx-state-tree";
 
 import Utils from "../utils";
-import BaseTool from "./Base";
+import BaseTool, { MIN_SIZE } from "./Base";
 import ToolMixin from "../mixins/Tool";
 import { RectRegionModel } from "../regions/RectRegion";
 import { guidGenerator, restoreNewsnapshot } from "../core/Helpers";
-
-const minSize = { w: 3, h: 3 };
+import lodash from "../utils/lodash";
 
 const _Tool = types
   .model({
@@ -36,13 +35,13 @@ const _Tool = types
       return rect;
     },
 
-    updateDraw(x, y) {
+    updateDraw: lodash.throttle(function(x, y) {
       const shape = self.getActiveShape;
 
       const { x1, y1, x2, y2 } = Utils.Image.reverseCoordinates({ x: shape.startX, y: shape.startY }, { x: x, y: y });
 
       shape.setPosition(x1, y1, x2 - x1, y2 - y1, shape.rotation);
-    },
+    }, 48), // 4 frames, optimized enough and not laggy yet
 
     mousedownEv(ev, [x, y]) {
       if (self.control.type === "rectanglelabels" && !self.control.isSelected) return;
@@ -78,7 +77,7 @@ const _Tool = types
 
       const s = self.getActiveShape;
 
-      if (s.width < minSize.w || s.height < minSize.h) {
+      if (s.width < MIN_SIZE.X || s.height < MIN_SIZE.Y) {
         destroy(s);
         if (self.control.type === "rectanglelabels") self.control.unselectAll();
       } else {

--- a/src/tools/Rect.js
+++ b/src/tools/Rect.js
@@ -1,11 +1,10 @@
 import { types, destroy } from "mobx-state-tree";
 
-import Utils from "../utils";
 import BaseTool, { MIN_SIZE } from "./Base";
 import ToolMixin from "../mixins/Tool";
 import { RectRegionModel } from "../regions/RectRegion";
 import { guidGenerator, restoreNewsnapshot } from "../core/Helpers";
-import lodash from "../utils/lodash";
+import { DrawingTool } from "../mixins/DrawingTool";
 
 const _Tool = types
   .model({
@@ -34,14 +33,6 @@ const _Tool = types
 
       return rect;
     },
-
-    updateDraw: lodash.throttle(function(x, y) {
-      const shape = self.getActiveShape;
-
-      const { x1, y1, x2, y2 } = Utils.Image.reverseCoordinates({ x: shape.startX, y: shape.startY }, { x: x, y: y });
-
-      shape.setPosition(x1, y1, x2 - x1, y2 - y1, shape.rotation);
-    }, 48), // 4 frames, optimized enough and not laggy yet
 
     mousedownEv(ev, [x, y]) {
       if (self.control.type === "rectanglelabels" && !self.control.isSelected) return;
@@ -88,6 +79,6 @@ const _Tool = types
     },
   }));
 
-const Rect = types.compose(ToolMixin, BaseTool, _Tool);
+const Rect = types.compose(ToolMixin, BaseTool, DrawingTool, _Tool);
 
 export { Rect };


### PR DESCRIPTION
It's fine, but there is a huge problem with rotation — we have to calculate bounding rect.
And do we really need it? Shape can be used to label some object near or on the border.