### PR TITLE
Add clickableLinks param to HyperText

### DIFF
--- a/src/tags/object/HyperText.js
+++ b/src/tags/object/HyperText.js
@@ -23,6 +23,7 @@ import { runTemplate } from "../../core/Template";
  * @param {string} value - value of the element
  * @param {boolean} [showLabels=false] - show labels next to the region
  * @param {string} [encoding=none|base64|base64unicode]  - decode value from encoded string
+ * @param {boolean} [clickableLinks=false] - allow to open resources from links
  */
 const TagAttrs = types.model("HyperTextModel", {
   name: types.maybeNull(types.string),
@@ -32,6 +33,7 @@ const TagAttrs = types.model("HyperTextModel", {
   savetextresult: types.optional(types.enumeration(["none", "no", "yes"]), () =>
     window.LS_SECURE_MODE ? "no" : "yes",
   ),
+  clickablelinks: false,
 
   highlightcolor: types.maybeNull(types.string),
   showlabels: types.optional(types.boolean, false),
@@ -235,12 +237,14 @@ class HyperTextPieceView extends Component {
       }
     });
 
-    Array.from(this.myRef.current.getElementsByTagName("a")).forEach(a => {
-      a.addEventListener("click", function(ev) {
-        ev.preventDefault();
-        return false;
+    if (!item.clickablelinks) {
+      Array.from(this.myRef.current.getElementsByTagName("a")).forEach(a => {
+        a.addEventListener("click", function(ev) {
+          ev.preventDefault();
+          return false;
+        });
       });
-    });
+    }
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Allow links to be clickable to open resources from HTML document.