### PR TITLE
Fix BrushRegion relations creation

### DIFF
--- a/src/components/RelationsOverlay/BoundingBox.js
+++ b/src/components/RelationsOverlay/BoundingBox.js
@@ -1,4 +1,4 @@
-import { wrapArray } from "../../utils/utilities";
+import { flatten, wrapArray } from "../../utils/utilities";
 import { Geometry } from "./Geometry";
 
 /**
@@ -99,7 +99,7 @@ const _detect = region => {
       };
     }
     case "brushregion": {
-      const points = wrapArray(region.touches.filter(t => t.type === "add").map(t => t.points));
+      const points = flatten(wrapArray(region.touches.filter(t => t.type === "add").map(t => Array.from(t.points))));
       return imageRelatedBBox(region, Geometry.getBrushBBox(points));
     }
     default: {

--- a/src/regions/Area.js
+++ b/src/regions/Area.js
@@ -8,6 +8,7 @@ import { TextRegionModel } from "./TextRegion";
 import { HyperTextRegionModel } from "./HyperTextRegion";
 import { PolygonRegionModel } from "./PolygonRegion";
 import { EllipseRegionModel } from "./EllipseRegion";
+import { BrushRegionModel } from "./BrushRegion";
 
 // general Area type for classification Results which doesn't belong to any real Area
 const ClassificationArea = types.compose(
@@ -45,6 +46,7 @@ const Area = types.union(
   KeyPointRegionModel,
   EllipseRegionModel,
   PolygonRegionModel,
+  BrushRegionModel,
   ClassificationArea,
 );
 


### PR DESCRIPTION
It was impossible to create relations between `BrushRegion` and any other region.
This PR resolves this issue.