### PR TITLE
Add `fixedScale` param to TimeSeries, default off

### DIFF
--- a/src/env/development.js
+++ b/src/env/development.js
@@ -48,7 +48,7 @@ import { TimeSeries } from "../examples/timeseries"; // eslint-disable-line no-u
  */
 // import { AllTypes } from "../examples/all_types"; // eslint-disable-line no-unused-vars
 
-const data = Taxonomy;
+const data = TimeSeries;
 
 /**
  * Get current config

--- a/src/tags/object/TimeSeries.js
+++ b/src/tags/object/TimeSeries.js
@@ -59,6 +59,7 @@ import "./TimeSeries/Channel";
  * @param {string} [timeDisplayFormat] format used to display temporal value, can be a number or a date, if a temporal column is a date then use strftime to format it, otherwise, if it's a number then use [d3 number](https://github.com/d3/d3-format#locale_format) formatting
  * @param {string} [sep] separator for you CSV file, default is comma ","
  * @param {string} [overviewChannels] comma-separated list of channels names or indexes displayed in overview
+ * @param {boolean} [fixedScale=false] always scale y-axis to the maximum to fit all the values; if false current view scales to fit only displayed values
  */
 const TagAttrs = types.model({
   name: types.identifier,
@@ -70,6 +71,8 @@ const TagAttrs = types.model({
   timeformat: "",
   timedisplayformat: "",
   overviewchannels: "", // comma-separated list of channels to show
+
+  fixedscale: false,
 
   multiaxis: types.optional(types.boolean, false), // show channels in the same view
   // visibilitycontrols: types.optional(types.boolean, false), // show channel visibility controls


### PR DESCRIPTION
On: don't scale y axis at all, always fit for all the values on channel
Off: scale to fit currently displayed data
Can be changed globally for TimeSeries and locally on Channel