### PR TITLE
Added parameters to set range of y-axis for timeseries

### DIFF
--- a/src/tags/object/TimeSeries.js
+++ b/src/tags/object/TimeSeries.js
@@ -63,6 +63,8 @@ import "./TimeSeries/Channel";
  * @param {string} [sep] separator for you CSV file, default is comma ","
  * @param {string} [overviewChannels] comma-separated list of channels names or indexes displayed in overview
  * @param {boolean} [fixedScale=false] always scale y-axis to the maximum to fit all the values; if false current view scales to fit only displayed values
+ * @param {float} [lowerBound] scale y-axis to the set lower value. Respects the value of fixedScale.
+ * @param {float} [upperBound] scale y-axis to the set upper value. Respects the value of fixedScale.
  */
 const TagAttrs = types.model({
   name: types.identifier,
@@ -76,6 +78,8 @@ const TagAttrs = types.model({
   overviewchannels: "", // comma-separated list of channels to show
 
   fixedscale: false,
+  upperbound: 0.0,
+  lowerbound: 0.0,
 
   multiaxis: types.optional(types.boolean, false), // show channels in the same view
   // visibilitycontrols: types.optional(types.boolean, false), // show channel visibility controls


### PR DESCRIPTION
This feature adds parameters to set fixed values for the range of the y-axis of a time series. The parameters are called "upperBound" and "lowerBound". It is sufficient to set only one of the parameters. The unset bound will respect the value of the parameter "fixedScalce".
As a sideeffect when the lower bound is greater than the upper bound, the graph will be inverted. This can be a positive or negative effect. It remains open for discussion if this is a wanted effect.