### PR TITLE
Switching visibility for all regions at once

### DIFF
--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -203,6 +203,11 @@ const countKonvaShapes = async done => {
   done(count);
 };
 
+const switchRegionTreeView = (viewName, done) => {
+  Htx.annotationStore.selected.regionStore.setView(viewName);
+  done();
+};
+
 const serialize = () => window.Htx.annotationStore.selected.serializeAnnotation();
 
 module.exports = {
@@ -220,6 +225,7 @@ module.exports = {
   polygonKonva,
   dragKonva,
   countKonvaShapes,
+  switchRegionTreeView,
 
   serialize,
 };

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -190,6 +190,19 @@ const dragKonva = async (x, y, shiftX, shiftY, done) => {
   done();
 };
 
+/**
+ * Count shapes on Konva, founded by selector
+ * @param {string|function} selector from Konva's finding methods params
+ * @param {function} done
+ */
+const countKonvaShapes = async done => {
+  const stage = window.Konva.stages[0];
+  const count = stage.find(node => {
+    return node.getType() === "Shape" && node.isVisible();
+  }).length;
+  done(count);
+};
+
 const serialize = () => window.Htx.annotationStore.selected.serializeAnnotation();
 
 module.exports = {
@@ -206,6 +219,7 @@ module.exports = {
   clickMultipleKonva,
   polygonKonva,
   dragKonva,
+  countKonvaShapes,
 
   serialize,
 };

--- a/e2e/tests/image.toggle-visibility.test.js
+++ b/e2e/tests/image.toggle-visibility.test.js
@@ -1,0 +1,113 @@
+const assert = require("assert");
+const { initLabelStudio, waitForImage, countKonvaShapes } = require("./helpers");
+
+const config = `
+<View>
+  <Image name="img" value="$image"></Image>
+  <RectangleLabels name="tag" toName="img" fillOpacity="0.5" strokeWidth="5">
+    <Label value="Planet"></Label>
+    <Label value="Moonwalker" background="blue"></Label>
+  </RectangleLabels>
+</View>
+`;
+
+const data = {
+  image:
+    "https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg",
+};
+
+const createRegion = (from_name, type, values) => ({
+  id: createRegion.id++,
+  source: "$image",
+  from_name,
+  to_name: "img",
+  type,
+  value: {
+    height: 10.458911419423693,
+    rotation: 0,
+    width: 12.4,
+    x: 50.8,
+    y: 5.869797225186766,
+    ...values,
+  },
+});
+createRegion.id = 1;
+
+const annotations = [
+  {
+    id: "1001",
+    lead_time: 15.053,
+    result: [
+      createRegion("tag", "rectanglelabels", { rectanglelabels: ["Moonwalker"] }),
+      createRegion("tag", "rectanglelabels", { rectanglelabels: ["Planet"], x: 1 }),
+      createRegion("tag", "rectanglelabels", { rectanglelabels: ["Planet"], y: 60 }),
+    ],
+  },
+];
+
+Feature("Toggle image's regions visibility");
+
+Scenario.only("Checking mass toggling of visibility", async I => {
+  const ALL_VISIBLE_SELECTOR = "[class^=Entities_header] [aria-label=eye]";
+  const ALL_HIDDEN_SELECTOR = "[class^=Entities_header] [aria-label=eye-invisible]";
+  const ONE_VISIBLE_SELECTOR = "[class^=Entities_header] ~ .ant-tree [aria-label=eye]";
+  const ONE_HIDDEN_SELECTOR = "[class^=Entities_header] ~ .ant-tree [aria-label=eye-invisible]";
+
+  const checkVisible = async num => {
+    switch (num) {
+      case 0:
+        I.seeElement(ALL_HIDDEN_SELECTOR);
+        I.seeElement(ONE_HIDDEN_SELECTOR);
+        I.dontSeeElement(ONE_VISIBLE_SELECTOR);
+        break;
+      case 1:
+      case 2:
+        I.seeElement(ALL_VISIBLE_SELECTOR);
+        I.seeElement(ONE_VISIBLE_SELECTOR);
+        I.seeElement(ONE_HIDDEN_SELECTOR);
+        break;
+      case 3:
+        I.seeElement(ALL_VISIBLE_SELECTOR);
+        I.seeElement(ONE_VISIBLE_SELECTOR);
+        I.dontSeeElement(ONE_HIDDEN_SELECTOR);
+        break;
+    }
+    let count = await I.executeAsyncScript(countKonvaShapes);
+    assert.equal(count, num);
+  };
+  const hideAll = () => {
+    I.click(ALL_VISIBLE_SELECTOR);
+  };
+  const showAll = () => {
+    I.click(ALL_HIDDEN_SELECTOR);
+  };
+  const hideOne = () => {
+    I.click(ONE_VISIBLE_SELECTOR);
+  };
+  const showOne = () => {
+    I.click(ONE_HIDDEN_SELECTOR);
+  };
+
+  await I.amOnPage("/");
+  I.executeAsyncScript(initLabelStudio, { annotations, config, data });
+  I.waitForVisible("canvas", 3);
+  I.executeAsyncScript(waitForImage);
+  I.see("Regions (3)");
+  await checkVisible(3);
+  hideOne();
+  await checkVisible(2);
+  showOne();
+  await checkVisible(3);
+  hideAll();
+  await checkVisible(0);
+  showOne();
+  await checkVisible(1);
+  hideOne();
+  await checkVisible(0);
+  showAll();
+  await checkVisible(3);
+  hideOne();
+  await checkVisible(2);
+  hideAll();
+  await checkVisible(0);
+});

--- a/e2e/tests/image.toggle-visibility.test.js
+++ b/e2e/tests/image.toggle-visibility.test.js
@@ -39,15 +39,15 @@ const annotations = [
     lead_time: 15.053,
     result: [
       createRegion("tag", "rectanglelabels", { rectanglelabels: ["Moonwalker"] }),
-      createRegion("tag", "rectanglelabels", { rectanglelabels: ["Planet"], x: 1 }),
-      createRegion("tag", "rectanglelabels", { rectanglelabels: ["Planet"], y: 60 }),
+      createRegion("tag", "rectanglelabels", { rectanglelabels: ["Moonwalker"], x: 1 }),
+      createRegion("tag", "rectanglelabels", { rectanglelabels: ["Moonwalker"], y: 60 }),
     ],
   },
 ];
 
 Feature("Toggle image's regions visibility");
 
-Scenario.only("Checking mass toggling of visibility", async I => {
+Scenario("Checking mass toggling of visibility", async I => {
   const ALL_VISIBLE_SELECTOR = "[class^=Entities_header] [aria-label=eye]";
   const ALL_HIDDEN_SELECTOR = "[class^=Entities_header] [aria-label=eye-invisible]";
   const ONE_VISIBLE_SELECTOR = "[class^=Entities_header] ~ .ant-tree [aria-label=eye]";
@@ -90,9 +90,77 @@ Scenario.only("Checking mass toggling of visibility", async I => {
 
   await I.amOnPage("/");
   I.executeAsyncScript(initLabelStudio, { annotations, config, data });
-  I.waitForVisible("canvas", 3);
   I.executeAsyncScript(waitForImage);
+  I.waitForVisible("canvas", 3);
   I.see("Regions (3)");
+  await checkVisible(3);
+  hideOne();
+  await checkVisible(2);
+  showOne();
+  await checkVisible(3);
+  hideAll();
+  await checkVisible(0);
+  showOne();
+  await checkVisible(1);
+  hideOne();
+  await checkVisible(0);
+  showAll();
+  await checkVisible(3);
+  hideOne();
+  await checkVisible(2);
+  hideAll();
+  await checkVisible(0);
+});
+
+Scenario("Checking regions grouped by label", async I => {
+  const ALL_VISIBLE_SELECTOR = "[class^=Entities_treelabel] [aria-label=eye]";
+  const ALL_HIDDEN_SELECTOR = "[class^=Entities_treelabel] [aria-label=eye-invisible]";
+  const ONE_VISIBLE_SELECTOR = "[class^=Entities_treelabel] ~ div [aria-label=eye]";
+  const ONE_HIDDEN_SELECTOR = "[class^=Entities_treelabel] ~ div [aria-label=eye-invisible]";
+
+  const checkVisible = async num => {
+    switch (num) {
+      case 0:
+        I.seeElement(ALL_HIDDEN_SELECTOR);
+        I.seeElement(ONE_HIDDEN_SELECTOR);
+        I.dontSeeElement(ONE_VISIBLE_SELECTOR);
+        break;
+      case 1:
+      case 2:
+        I.seeElement(ALL_VISIBLE_SELECTOR);
+        I.seeElement(ONE_VISIBLE_SELECTOR);
+        I.seeElement(ONE_HIDDEN_SELECTOR);
+        break;
+      case 3:
+        I.seeElement(ALL_VISIBLE_SELECTOR);
+        I.seeElement(ONE_VISIBLE_SELECTOR);
+        I.dontSeeElement(ONE_HIDDEN_SELECTOR);
+        break;
+    }
+    let count = await I.executeAsyncScript(countKonvaShapes);
+    assert.equal(count, num);
+  };
+  const hideAll = () => {
+    I.click(ALL_VISIBLE_SELECTOR);
+  };
+  const showAll = () => {
+    I.click(ALL_HIDDEN_SELECTOR);
+  };
+  const hideOne = () => {
+    I.click(ONE_VISIBLE_SELECTOR);
+  };
+  const showOne = () => {
+    I.click(ONE_HIDDEN_SELECTOR);
+  };
+
+  await I.amOnPage("/");
+  I.executeAsyncScript(initLabelStudio, { annotations, config, data });
+  I.executeAsyncScript(waitForImage);
+  I.waitForVisible("canvas", 3);
+  I.moveCursorTo({ react: "Card Divider Dropdown" });
+  I.click({ react: "MenuItem", props: { eventKey: "labels" } });
+  I.moveCursorTo({ react: "div" });
+
   await checkVisible(3);
   hideOne();
   await checkVisible(2);

--- a/e2e/tests/image.toggle-visibility.test.js
+++ b/e2e/tests/image.toggle-visibility.test.js
@@ -47,7 +47,7 @@ const annotations = [
 
 Feature("Toggle image's regions visibility");
 
-Scenario("Checking mass toggling of visibility", async I => {
+Scenario("Checking mass toggling of visibility", async (I, AtImageView) => {
   const ALL_VISIBLE_SELECTOR = "[class^=Entities_header] [aria-label=eye]";
   const ALL_HIDDEN_SELECTOR = "[class^=Entities_header] [aria-label=eye-invisible]";
   const ONE_VISIBLE_SELECTOR = "[class^=Entities_header] ~ .ant-tree [aria-label=eye]";
@@ -90,7 +90,7 @@ Scenario("Checking mass toggling of visibility", async I => {
 
   await I.amOnPage("/");
   I.executeAsyncScript(initLabelStudio, { annotations, config, data });
-  I.executeAsyncScript(waitForImage);
+  AtImageView.waitForImage();
   I.waitForVisible("canvas", 3);
   I.see("Regions (3)");
   await checkVisible(3);
@@ -112,7 +112,22 @@ Scenario("Checking mass toggling of visibility", async I => {
   await checkVisible(0);
 });
 
-Scenario("Checking regions grouped by label", async I => {
+Scenario("Hiding of mass visibility switcher", (I, AtImageView) => {
+  const ALL_VISIBILITY_TOGGLE_SELECTOR = "[class^=Entities_header] [aria-label^=eye]";
+
+  I.amOnPage("/");
+  I.executeAsyncScript(initLabelStudio, { config, data });
+  AtImageView.waitForImage();
+  I.waitForVisible("canvas", 3);
+  I.see("Regions (0)");
+  I.dontSeeElement(ALL_VISIBILITY_TOGGLE_SELECTOR);
+  I.click(locate(".ant-tag").withText("Planet"));
+  AtImageView.dragKonva(300, 300, 50, 50);
+  I.see("Regions (1)");
+  I.seeElement(ALL_VISIBILITY_TOGGLE_SELECTOR);
+});
+
+Scenario("Checking regions grouped by label", async (I, AtImageView) => {
   const ALL_VISIBLE_SELECTOR = "[class^=Entities_treelabel] [aria-label=eye]";
   const ALL_HIDDEN_SELECTOR = "[class^=Entities_treelabel] [aria-label=eye-invisible]";
   const ONE_VISIBLE_SELECTOR = "[class^=Entities_treelabel] ~ div [aria-label=eye]";
@@ -155,7 +170,7 @@ Scenario("Checking regions grouped by label", async I => {
 
   await I.amOnPage("/");
   I.executeAsyncScript(initLabelStudio, { annotations, config, data });
-  I.executeAsyncScript(waitForImage);
+  AtImageView.waitForImage();
   I.waitForVisible("canvas", 3);
   I.executeAsyncScript(switchRegionTreeView, "labels");
   I.see("Labels");

--- a/e2e/tests/image.toggle-visibility.test.js
+++ b/e2e/tests/image.toggle-visibility.test.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { initLabelStudio, waitForImage, countKonvaShapes } = require("./helpers");
+const { initLabelStudio, waitForImage, countKonvaShapes, switchRegionTreeView } = require("./helpers");
 
 const config = `
 <View>
@@ -157,10 +157,8 @@ Scenario("Checking regions grouped by label", async I => {
   I.executeAsyncScript(initLabelStudio, { annotations, config, data });
   I.executeAsyncScript(waitForImage);
   I.waitForVisible("canvas", 3);
-  I.moveCursorTo(locate(".ant-dropdown-trigger").withText("Regions (3)"));
-  I.click(locate(".ant-menu-item").withText("Labels"));
-  I.click(locate("div").withText("Results"));
-
+  I.executeAsyncScript(switchRegionTreeView, "labels");
+  I.see("Labels");
   await checkVisible(3);
   hideOne();
   await checkVisible(2);

--- a/e2e/tests/image.toggle-visibility.test.js
+++ b/e2e/tests/image.toggle-visibility.test.js
@@ -157,9 +157,9 @@ Scenario("Checking regions grouped by label", async I => {
   I.executeAsyncScript(initLabelStudio, { annotations, config, data });
   I.executeAsyncScript(waitForImage);
   I.waitForVisible("canvas", 3);
-  I.moveCursorTo({ react: "Card Divider Dropdown" });
-  I.click({ react: "MenuItem", props: { eventKey: "labels" } });
-  I.moveCursorTo({ react: "div" });
+  I.moveCursorTo(locate(".ant-dropdown-trigger").withText("Regions (3)"));
+  I.click(locate(".ant-menu-item").withText("Labels"));
+  I.click(locate("div").withText("Results"));
 
   await checkVisible(3);
   hideOne();

--- a/src/components/Entities/Entities.js
+++ b/src/components/Entities/Entities.js
@@ -69,7 +69,7 @@ const RegionItem = observer(({ item, idx, flat }) => {
           type="text"
           icon={item.hidden ? <EyeInvisibleOutlined /> : <EyeOutlined />}
           onClick={item.toggleHidden}
-          className={item.hidden ? styles.hidden : styles.visible}
+          className={[styles.lstitem__actionIcon, item.hidden ? styles.hidden : styles.visible].join(" ")}
         />
       )}
 
@@ -87,17 +87,30 @@ const RegionItem = observer(({ item, idx, flat }) => {
   );
 });
 
-const LabelItem = observer(({ item, idx }) => {
+const LabelItem = observer(({ item, idx, regions, regionStore }) => {
   const bg = item.background;
   const labelStyle = {
     backgroundColor: bg,
     color: item.selectedcolor,
   };
-
+  const isHidden = Object.values(regions).reduce((acc, item) => acc && item.hidden, true);
   return (
-    <Tag style={labelStyle} className={styles.treetag} size={item.size}>
-      {item._value}
-    </Tag>
+    <List.Item key={item.id} className={[styles.lstitem, styles.lstitem_label].join(" ")}>
+      <Tag style={labelStyle} className={styles.treetag} size={item.size}>
+        {item._value}
+      </Tag>
+      <div className={styles.lstitem__actions}>
+        <Button
+          size="small"
+          type="text"
+          icon={isHidden ? <EyeInvisibleOutlined /> : <EyeOutlined />}
+          onClick={() => {
+            regionStore.setHiddenByLabel(!isHidden, item);
+          }}
+          className={[styles.lstitem__actionIcon, isHidden ? styles.uihidden : styles.uivisible].join(" ")}
+        />
+      </div>
+    </List.Item>
   );
 });
 
@@ -170,10 +183,14 @@ const SortMenu = observer(({ regionStore }) => {
 });
 
 const LabelsList = observer(({ regionStore }) => {
-  const treeData = regionStore.asLabelsTree((item, idx, isLabel) => {
+  const treeData = regionStore.asLabelsTree((item, idx, isLabel, children) => {
     return {
       key: item.id,
-      title: isLabel ? <LabelItem item={item} idx={idx} /> : <RegionItem item={item} idx={idx} />,
+      title: isLabel ? (
+        <LabelItem item={item} idx={idx} regions={children} regionStore={regionStore} />
+      ) : (
+        <RegionItem item={item} idx={idx} />
+      ),
       className: isLabel ? styles.treelabel : null,
     };
   });
@@ -339,7 +356,6 @@ export default observer(({ store, regionStore }) => {
           <Button
             size="small"
             type="link"
-            ghost
             className={regionStore.isAllHidden ? styles.uihidden : styles.uivisible}
             onClick={toggleVisibility}
           >

--- a/src/components/Entities/Entities.js
+++ b/src/components/Entities/Entities.js
@@ -315,18 +315,16 @@ export default observer(({ store, regionStore }) => {
   const { classifications, regions } = regionStore;
   const count = regions.length + (regionStore.view === "regions" ? classifications.length : 0);
 
+  const toggleVisibility = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    regionStore.toggleVisibility();
+  };
+
   return (
-    <div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          paddingLeft: "4px",
-          paddingRight: "4px",
-          alignItems: "center",
-        }}
-      >
-        <div style={{ flex: 1 }}>
+    <div className={styles.section}>
+      <div className={styles.header}>
+        <div className={styles.title}>
           {/* override LS styles' height */}
           <Divider dashed orientation="left" style={{ height: "auto" }}>
             <Dropdown overlay={<GroupMenu regionStore={regionStore} />} placement="bottomLeft">
@@ -336,6 +334,17 @@ export default observer(({ store, regionStore }) => {
               </span>
             </Dropdown>
           </Divider>
+        </div>
+        <div>
+          <Button
+            size="small"
+            type="link"
+            ghost
+            className={regionStore.isAllHidden ? styles.uihidden : styles.uivisible}
+            onClick={toggleVisibility}
+          >
+            {regionStore.isAllHidden ? <EyeInvisibleOutlined /> : <EyeOutlined />}
+          </Button>
         </div>
         {count > 0 && regionStore.view === "regions" && (
           <Dropdown overlay={<SortMenu regionStore={regionStore} />} placement="bottomLeft">

--- a/src/components/Entities/Entities.js
+++ b/src/components/Entities/Entities.js
@@ -352,16 +352,18 @@ export default observer(({ store, regionStore }) => {
             </Dropdown>
           </Divider>
         </div>
-        <div>
-          <Button
-            size="small"
-            type="link"
-            className={regionStore.isAllHidden ? styles.uihidden : styles.uivisible}
-            onClick={toggleVisibility}
-          >
-            {regionStore.isAllHidden ? <EyeInvisibleOutlined /> : <EyeOutlined />}
-          </Button>
-        </div>
+        {count > 0 ? (
+          <div>
+            <Button
+              size="small"
+              type="link"
+              className={regionStore.isAllHidden ? styles.uihidden : styles.uivisible}
+              onClick={toggleVisibility}
+            >
+              {regionStore.isAllHidden ? <EyeInvisibleOutlined /> : <EyeOutlined />}
+            </Button>
+          </div>
+        ) : null}
         {count > 0 && regionStore.view === "regions" && (
           <Dropdown overlay={<SortMenu regionStore={regionStore} />} placement="bottomLeft">
             <span className={globalStyles.link} onClick={e => e.preventDefault()}>

--- a/src/components/Entities/Entities.js
+++ b/src/components/Entities/Entities.js
@@ -352,7 +352,7 @@ export default observer(({ store, regionStore }) => {
             </Dropdown>
           </Divider>
         </div>
-        {count > 0 ? (
+        {regions.length > 0 ? (
           <div>
             <Button
               size="small"

--- a/src/components/Entities/Entities.js
+++ b/src/components/Entities/Entities.js
@@ -92,12 +92,10 @@ const LabelItem = observer(({ item, idx }) => {
   const labelStyle = {
     backgroundColor: bg,
     color: item.selectedcolor,
-    cursor: "pointer",
-    margin: "5px",
   };
 
   return (
-    <Tag style={labelStyle} size={item.size}>
+    <Tag style={labelStyle} className={styles.treetag} size={item.size}>
       {item._value}
     </Tag>
   );
@@ -176,6 +174,7 @@ const LabelsList = observer(({ regionStore }) => {
     return {
       key: item.id,
       title: isLabel ? <LabelItem item={item} idx={idx} /> : <RegionItem item={item} idx={idx} />,
+      className: isLabel ? styles.treelabel : null,
     };
   });
 

--- a/src/components/Entities/Entities.module.scss
+++ b/src/components/Entities/Entities.module.scss
@@ -1,3 +1,16 @@
+.section {
+  .header {
+    display: flex;
+    justify-content: space-between;
+    padding-left: 4px;
+    padding-right: 4px;
+    align-items: center;
+  }
+  .title {
+    flex: 1;
+  }
+}
+
 .treelabels {
   border: 1px solid #d9d9d9;
   max-height: 350px;
@@ -74,6 +87,14 @@
 
 .list .lstitem {
   border-bottom: none;
+}
+
+.uihidden {
+  opacity: 0.5;
+}
+
+.uivisible {
+  opacity: 1;
 }
 
 .ant-tree-switcher {

--- a/src/components/Entities/Entities.module.scss
+++ b/src/components/Entities/Entities.module.scss
@@ -83,6 +83,24 @@
   &.selected {
     background: #bae7ff;
   }
+
+  &_label {
+    justify-content: space-between;
+  }
+
+  &__actions {
+    flex: 0 0 auto;
+
+    & [role="img"] {
+      margin: 0;
+    }
+  }
+
+  &__actionIcon {
+    flex: 0 0 auto;
+    text-align: center;
+    justify-content: center;
+  }
 }
 
 .list .lstitem {

--- a/src/components/Entities/Entities.module.scss
+++ b/src/components/Entities/Entities.module.scss
@@ -4,6 +4,18 @@
   overflow-y: auto;
 }
 
+.treelabel :global(.ant-tree-node-content-wrapper) {
+  cursor: default;
+}
+
+.treetag {
+  margin: "5px";
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .item {
   color: get-color(error);
   font-size: 14px;

--- a/src/components/Relations/Relations.js
+++ b/src/components/Relations/Relations.js
@@ -157,9 +157,9 @@ export default observer(({ store }) => {
             <Button
               size="small"
               type="link"
-              icon={relationsUIVisible ? <EyeInvisibleOutlined /> : <EyeOutlined />}
+              icon={!relationsUIVisible ? <EyeInvisibleOutlined /> : <EyeOutlined />}
               onClick={() => annotation.relationStore.toggleConnections()}
-              className={[relationsUIVisible ? styles.uihidden : styles.uivisible, globalStyles.link]}
+              className={[!relationsUIVisible ? styles.uihidden : styles.uivisible, globalStyles.link]}
             />
           </div>
         )}

--- a/src/stores/RegionStore.js
+++ b/src/stores/RegionStore.js
@@ -30,6 +30,10 @@ export default types
       return Array.from(self.annotation.areas.values()).filter(area => !area.classification);
     },
 
+    get isAllHidden() {
+      return !self.regions.find(area => !area.hidden);
+    },
+
     get sortedRegions() {
       const sorts = {
         date: isDesc => (isDesc ? self.regions : [...self.regions].reverse()),
@@ -211,5 +215,14 @@ export default types
       const next = regions[idx + 1] !== "undefined" ? regions[idx + 1] : regions[0];
 
       next && next.selectRegion();
+    },
+
+    toggleVisibility() {
+      const shouldBeHidden = !self.isAllHidden;
+      self.regions.forEach(area => {
+        if (area.hidden !== shouldBeHidden) {
+          area.toggleHidden();
+        }
+      });
     },
   }));

--- a/src/stores/RegionStore.js
+++ b/src/stores/RegionStore.js
@@ -98,7 +98,7 @@ export default types
       // create the tree
       let idx = 0;
       const tree = Object.keys(labels).map(lname => {
-        const el = enrich(labels[lname], idx, true);
+        const el = enrich(labels[lname], idx, true, map[lname]);
         el["children"] = map[lname].map(r => enrich(r, idx++));
 
         return el;
@@ -222,6 +222,20 @@ export default types
       self.regions.forEach(area => {
         if (area.hidden !== shouldBeHidden) {
           area.toggleHidden();
+        }
+      });
+    },
+
+    setHiddenByLabel(shouldBeHidden, label) {
+      self.regions.forEach(area => {
+        if (area.hidden !== shouldBeHidden) {
+          const l = area.labeling;
+          if (l) {
+            const selected = l.selectedLabels;
+            if (selected.includes(label)) {
+              area.toggleHidden();
+            }
+          }
         }
       });
     },


### PR DESCRIPTION
This pull request should add buttons for hiding and showing groups of regions. 
- Hide / show all regions.
- Hide / show some regions grouped by their label (in case of using "labels" view for region tree)