### PR TITLE
Fixes for rotation and zooming

### DIFF
--- a/e2e/codecept.conf.js
+++ b/e2e/codecept.conf.js
@@ -27,6 +27,7 @@ exports.config = {
   },
   include: {
     I: "./steps_file.js",
+    AtImageView: "./fragments/AtImageView.js",
   },
   bootstrap: null,
   mocha: {},

--- a/e2e/fragments/AtImageView.js
+++ b/e2e/fragments/AtImageView.js
@@ -1,0 +1,68 @@
+const { I } = inject();
+const {
+  waitForImage,
+  clickKonva,
+  polygonKonva,
+  dragKonva,
+  hasKonvaPixelColorAtPoint,
+  whereIsPixel,
+  getCanvasSize,
+  setZoom,
+} = require("../tests/helpers");
+
+module.exports = {
+  waitForImage() {
+    I.executeAsyncScript(waitForImage);
+  },
+
+  async getCanvasSize() {
+    const sizes = await I.executeAsyncScript(getCanvasSize);
+    return sizes;
+  },
+
+  setZoom(scale, x, y) {
+    I.executeAsyncScript(setZoom, scale, x, y);
+  },
+
+  /**
+   * Click once on the main Stage
+   * @param {number} x
+   * @param {number} y
+   */
+  clickKonva(x, y) {
+    I.executeAsyncScript(clickKonva, x, y);
+  },
+  /**
+   * Click multiple times on the main Stage
+   * @param {number[][]} points
+   */
+  clickPointsKonva(points) {
+    I.executeAsyncScript(polygonKonva, points);
+  },
+  /**
+   * Dragging between two points
+   * @param {number} x
+   * @param {number} y
+   * @param {number} shiftX
+   * @param {number} shiftY
+   */
+  dragKonva(x, y, shiftX, shiftY) {
+    I.executeAsyncScript(dragKonva, x, y, shiftX, shiftY);
+  },
+  /**
+   * Get  pixel color at point
+   * @param {number} x
+   * @param {number} y
+   * @param {number[]} rgbArray
+   * @param {number} tolerance
+   */
+  async hasPixelColor(x, y, rgbArray, tolerance = 3) {
+    const hasPixel = await I.executeAsyncScript(hasKonvaPixelColorAtPoint, x, y, rgbArray, tolerance);
+    return hasPixel;
+  },
+  // Only for debugging
+  async whereIsPixel(rgbArray, tolerance = 3) {
+    const points = await I.executeAsyncScript(whereIsPixel, rgbArray, tolerance);
+    return points;
+  },
+};

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -144,7 +144,7 @@ const polygonKonva = async (points, done) => {
     const delay = () => new Promise(resolve => setTimeout(resolve, 10));
     const stage = window.Konva.stages[0];
     for (let point of points) {
-      stage.fire("click", { evt: { offsetX: point[0], offsetY: point[1] } });
+      stage.fire("click", { evt: { offsetX: point[0], offsetY: point[1], preventDefault: () => {} } });
       await delay();
     }
 
@@ -158,7 +158,7 @@ const polygonKonva = async (points, done) => {
     firstPoint.fire("mouseover");
     await delay();
     // and only after that we can click on it
-    firstPoint.fire("click");
+    firstPoint.fire("click", { evt: { preventDefault: () => {} } });
     done();
   } catch (e) {
     done(String(e));
@@ -190,7 +190,70 @@ const dragKonva = async (x, y, shiftX, shiftY, done) => {
   done();
 };
 
+/**
+ * Check if there is layer with given color at given coords
+ * @param {number} x
+ * @param {number} y
+ * @param {number[]} rgbArray
+ * @param {function} done
+ * @param {number} tolerance
+ */
+const hasKonvaPixelColorAtPoint = (x, y, rgbArray, tolerance, done) => {
+  const stage = window.Konva.stages[0];
+  const areEqualRGB = (a, b) => {
+    for (let i = 3; i--; ) {
+      if (Math.abs(a[i] - b[i]) > tolerance) {
+        return false;
+      }
+    }
+    return true;
+  };
+  for (let layer of stage.getLayers()) {
+    const rgba = layer.getContext().getImageData(x, y, 1, 1).data;
+    if (areEqualRGB(rgbArray, rgba)) {
+      done(true);
+      return;
+    }
+  }
+  done(false);
+  return;
+};
+const getCanvasSize = done => {
+  const stage = window.Konva.stages[0];
+  done({ width: Math.floor(stage.width()) - 1, height: Math.floor(stage.height()) - 1 });
+};
+const setZoom = (scale, x, y, done) => {
+  Htx.annotationStore.selected.objects.find(o => o.type === "image").setZoom(scale, x, y);
+  done();
+};
+
 const serialize = () => window.Htx.annotationStore.selected.serializeAnnotation();
+
+// Only for debugging
+const whereIsPixel = (rgbArray, tolerance, done) => {
+  const stage = window.Konva.stages[0];
+  const areEqualRGB = (a, b) => {
+    for (let i = 3; i--; ) {
+      if (Math.abs(a[i] - b[i]) > tolerance) {
+        return false;
+      }
+    }
+    return true;
+  };
+  let points = [];
+  for (let layer of stage.getLayers()) {
+    const canvas = layer.getCanvas();
+    for (let x = 0; x < canvas.width; x++) {
+      for (let y = 0; y < canvas.height; y++) {
+        const rgba = layer.getContext().getImageData(x, y, 1, 1).data;
+        if (areEqualRGB(rgbArray, rgba)) {
+          points.push([x, y]);
+        }
+      }
+    }
+  }
+  done(points);
+};
 
 module.exports = {
   initLabelStudio,
@@ -206,6 +269,10 @@ module.exports = {
   clickMultipleKonva,
   polygonKonva,
   dragKonva,
+  hasKonvaPixelColorAtPoint,
+  getCanvasSize,
+  setZoom,
+  whereIsPixel,
 
   serialize,
 };

--- a/e2e/tests/image.zoom-rotate.test.js
+++ b/e2e/tests/image.zoom-rotate.test.js
@@ -1,0 +1,178 @@
+/* global Feature, Scenario */
+
+const { initLabelStudio, serialize } = require("./helpers");
+
+const assert = require("assert");
+
+Feature("Zooming and rotating");
+
+const IMAGE =
+  "https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/images/nick-owuor-astro-nic-visuals-wDifg5xc9Z4-unsplash.jpg";
+
+const BLUEVIOLET = {
+  color: "#8A2BE2",
+  rgbArray: [138, 43, 226],
+};
+const getConfigWithShape = (shape, props = "") => `
+  <View>
+    <Image name="img" value="$image" zoom="true" zoomBy="1.5" zoomControl="true" rotateControl="true"></Image>
+    <${shape}Labels ${props} name="tag" toName="img">
+        <Label value="Test" background="${BLUEVIOLET.color}"></Label>
+    </${shape}Labels>
+  </View>`;
+
+const hScaleCoords = ([x, y], w, h) => {
+  const ratio = w / h;
+  return [x * ratio, y * ratio];
+};
+const rotateCoords = (point, degree, w, h) => {
+  const [x, y] = point;
+  if (!degree) return point;
+
+  degree = (360 + degree) % 360;
+  if (degree === 90) return hScaleCoords([h - y - 1, x], w, h);
+  if (degree === 270) return hScaleCoords([y, w - x - 1], w, h);
+  if (Math.abs(degree) === 180) return [w - x - 1, h - y - 1];
+  return [x, y];
+};
+
+const shapes = [
+  {
+    shape: "KeyPoint",
+    props: 'strokeWidth="5"',
+    action: "clickKonva",
+    regions: [
+      {
+        params: [100, 100],
+      },
+      {
+        params: [200, 100],
+      },
+    ],
+  },
+  {
+    shape: "Polygon",
+    action: "clickPointsKonva",
+    regions: [
+      {
+        params: [
+          [
+            [95, 95],
+            [95, 105],
+            [105, 105],
+            [105, 95],
+          ],
+        ],
+      },
+      {
+        params: [
+          [
+            [400, 10],
+            [400, 90],
+            [370, 30],
+            [300, 10],
+          ],
+        ],
+      },
+    ],
+  },
+  {
+    shape: "Rectangle",
+    action: "dragKonva",
+    regions: [
+      {
+        params: [95, 95, 10, 10],
+      },
+      {
+        params: [400, 350, -50, -50],
+      },
+    ],
+  },
+  {
+    shape: "Ellipse",
+    action: "dragKonva",
+    regions: [
+      {
+        params: [100, 100, 10, 10],
+      },
+      {
+        params: [230, 300, -50, -30],
+      },
+    ],
+  },
+];
+const shapesTable = new DataTable(["shape", "props", "action", "regions"]);
+shapes.forEach(({ shape, props = "", action, regions }) => {
+  shapesTable.add([shape, props, action, regions]);
+});
+
+Data(shapesTable).Scenario("Simple rotation", async function(I, AtImageView, current) {
+  const params = {
+    config: getConfigWithShape(current.shape, current.props),
+    data: { image: IMAGE },
+  };
+
+  I.amOnPage("/");
+  await I.executeAsyncScript(initLabelStudio, params);
+  AtImageView.waitForImage();
+  I.waitForVisible("canvas");
+  I.see("Regions (0)");
+  const canvasSize = await AtImageView.getCanvasSize();
+  for (let region of current.regions) {
+    I.pressKey("u");
+    I.pressKey("1");
+    AtImageView[current.action](...region.params);
+  }
+  const standard = await I.executeScript(serialize);
+  const rotationQueue = ["right", "right", "right", "right", "left", "left", "left", "left"];
+  let degree = 0;
+  let hasPixel = await AtImageView.hasPixelColor(100, 100, BLUEVIOLET.rgbArray);
+  assert.equal(hasPixel, true);
+  for (let rotate of rotationQueue) {
+    I.click(locate("button").withDescendant(`[aria-label='rotate-${rotate}']`));
+    degree += rotate === "right" ? 90 : -90;
+    hasPixel = await AtImageView.hasPixelColor(
+      ...rotateCoords([100, 100], degree, canvasSize.width, canvasSize.height).map(Math.round),
+      BLUEVIOLET.rgbArray,
+    );
+    assert.equal(hasPixel, true);
+    const result = await I.executeScript(serialize);
+    for (let i = 0; i < standard.length; i++) {
+      assert.deepEqual(standard[i].result, result[i].result);
+    }
+  }
+});
+
+Data(shapesTable).Scenario("Rotate zoomed", async function(I, AtImageView, current) {
+  const params = {
+    config: getConfigWithShape(current.shape, current.props),
+    data: { image: IMAGE },
+  };
+
+  I.amOnPage("/");
+  await I.executeAsyncScript(initLabelStudio, params);
+  AtImageView.waitForImage();
+  I.waitForVisible("canvas");
+  I.see("Regions (0)");
+  const canvasSize = await AtImageView.getCanvasSize();
+  for (let region of current.regions) {
+    I.pressKey("u");
+    I.pressKey("1");
+    AtImageView[current.action](...region.params);
+  }
+  const rotationQueue = ["right", "right", "right", "right", "left", "left", "left", "left"];
+  let degree = 0;
+  const ZOOM = 5;
+  AtImageView.setZoom(ZOOM, -100 * ZOOM, -100 * ZOOM);
+  let hasPixel = await AtImageView.hasPixelColor(0, 0, BLUEVIOLET.rgbArray);
+  assert.equal(hasPixel, true);
+  for (let rotate of rotationQueue) {
+    I.click(locate("button").withDescendant(`[aria-label='rotate-${rotate}']`));
+    degree += rotate === "right" ? 90 : -90;
+    hasPixel = await AtImageView.hasPixelColor(
+      ...rotateCoords([0, 0], degree, canvasSize.width, canvasSize.height).map(Math.round),
+      BLUEVIOLET.rgbArray,
+    );
+    assert.equal(hasPixel, true);
+  }
+});

--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -18,8 +18,8 @@ export default observer(
 
     handleOnClick = e => {
       const { item } = this.props;
-
-      return item.event("click", e, e.evt.offsetX, e.evt.offsetY);
+      let evt = e.evt || e;
+      return item.event("click", evt, evt.offsetX, evt.offsetY);
     };
 
     handleMouseDown = e => {
@@ -91,15 +91,10 @@ export default observer(
 
       item.freezeHistory();
 
-      const stage = item.stageRef;
-      const scale = stage.scaleX();
-
-      if (e.evt && (e.evt.buttons === 4 || (e.evt.buttons === 1 && e.evt.shiftKey)) && scale > 1) {
+      if (e.evt && (e.evt.buttons === 4 || (e.evt.buttons === 1 && e.evt.shiftKey)) && item.zoomScale > 1) {
         e.evt.preventDefault();
-        const newPos = { x: stage.x() + e.evt.movementX, y: stage.y() + e.evt.movementY };
-        item.setZoom(scale, newPos.x, newPos.y);
-        stage.position(newPos);
-        stage.batchDraw();
+        const newPos = { x: item.zoomingPositionX + e.evt.movementX, y: item.zoomingPositionY + e.evt.movementY };
+        item.setZoomPosition(newPos.x, newPos.y);
       } else {
         return item.event("mousemove", e, e.evt.offsetX, e.evt.offsetY);
       }
@@ -135,63 +130,11 @@ export default observer(
          */
         e.evt.preventDefault();
       }
-
-      const { item } = this.props;
-      item.freezeHistory();
-
-      const stage = item.stageRef;
-      const scaleBy = parseFloat(item.zoomby);
-      const oldScale = stage.scaleX();
-
-      let mousePointTo;
-      let newScale;
-      let pos;
-      let newPos;
-
       if (e.evt) {
-        mousePointTo = {
-          x: stage.getPointerPosition().x / oldScale - stage.x() / oldScale,
-          y: stage.getPointerPosition().y / oldScale - stage.y() / oldScale,
-        };
-
-        newScale = e.evt.deltaY > 0 ? oldScale * scaleBy : oldScale / scaleBy;
-
-        newPos = {
-          x: -(mousePointTo.x - stage.getPointerPosition().x / newScale) * newScale,
-          y: -(mousePointTo.y - stage.getPointerPosition().y / newScale) * newScale,
-        };
-      } else {
-        pos = {
-          x: stage.width() / 2,
-          y: stage.height() / 2,
-        };
-
-        mousePointTo = {
-          x: pos.x / oldScale - stage.x() / oldScale,
-          y: pos.y / oldScale - stage.y() / oldScale,
-        };
-
-        newScale = Math.max(0.05, oldScale * e);
-
-        newPos = {
-          x: -(mousePointTo.x - pos.x / newScale) * newScale,
-          y: -(mousePointTo.y - pos.y / newScale) * newScale,
-        };
+        const { item } = this.props;
+        const stage = item.stageRef;
+        item.handleZoom(e.evt.deltaY, stage.getPointerPosition());
       }
-
-      if (item.negativezoom !== true && newScale <= 1) {
-        item.setZoom(1, 0, 0);
-        stage.scale({ x: 1, y: 1 });
-        stage.position({ x: 0, y: 0 });
-        stage.batchDraw();
-        return;
-      }
-
-      stage.scale({ x: newScale, y: newScale });
-
-      item.setZoom(newScale, newPos.x, newPos.y);
-      stage.position(newPos);
-      stage.batchDraw();
     };
 
     renderRulers() {
@@ -303,7 +246,7 @@ export default observer(
         imgTransform.push(`translate(${translate[item.rotation] || "0, 0"})`);
         if ([90, 270].includes(item.rotation)) {
           // we can not rotate img itself, so we change container's size via css margin hack, ...
-          const ratio = item.naturalHeight / item.naturalWidth;
+          const ratio = item.naturalWidth / item.naturalHeight;
           filler = <div className={styles.filler} style={{ marginTop: `${ratio * 100}%` }} />;
           containerClassName += " " + styles.rotated;
           // ... prepare image size for transform rotation and use position: absolute
@@ -353,13 +296,16 @@ export default observer(
               }}
               style={{ position: "absolute", top: 0, left: 0, brightness: "150%" }}
               className={"image-element"}
-              width={item.stageWidth}
-              height={item.stageHeight}
-              scaleX={item.scale}
-              scaleY={item.scale}
+              width={item.stageComponentSize.width}
+              height={item.stageComponentSize.height}
+              scaleX={item.stageScale}
+              scaleY={item.stageScale}
               x={item.zoomingPositionX}
               y={item.zoomingPositionY}
               onClick={this.handleOnClick}
+              offsetX={item.stageTranslate.x}
+              offsetY={item.stageTranslate.y}
+              rotation={item.rotation}
               onMouseDown={this.handleMouseDown}
               onMouseMove={this.handleMouseMove}
               onMouseUp={this.handleMouseUp}

--- a/src/mixins/Regions.js
+++ b/src/mixins/Regions.js
@@ -56,6 +56,7 @@ const RegionsMixin = types
 
     // "web" degree is opposite to mathematical, -90 is 90 actually
     // swapSizes = true when canvas is already rotated at this moment
+    // @todo not used
     rotatePoint(point, degree, swapSizes = true) {
       const { x, y } = point;
       if (!degree) return { x, y };
@@ -76,9 +77,26 @@ const RegionsMixin = types
       return { x, y };
     },
 
+    // @todo not used
     rotateDimensions({ width, height }, degree) {
       if ((degree + 360) % 180 === 0) return { width, height };
       return { width: height, height: width };
+    },
+
+    convertXToPerc(x) {
+      return (x * 100) / self.parent.stageWidth;
+    },
+
+    convertYToPerc(y) {
+      return (y * 100) / self.parent.stageHeight;
+    },
+
+    convertHDimensionToPerc(hd) {
+      return (hd * (self.scaleX || 1) * 100) / self.parent.stageWidth;
+    },
+
+    convertVDimensionToPerc(vd) {
+      return (vd * (self.scaleY || 1) * 100) / self.parent.stageHeight;
     },
 
     // update region appearence based on it's current states, for

--- a/src/regions/EllipseRegion.js
+++ b/src/regions/EllipseRegion.js
@@ -113,6 +113,7 @@ const Model = types
       }
     },
 
+    // @todo not used
     rotate(degree) {
       const p = self.rotatePoint(self, degree);
       self.setPosition(p.x, p.y, self.radiusY, self.radiusX, self.rotation);
@@ -169,29 +170,15 @@ const Model = types
     },
 
     serialize() {
-      const { naturalWidth, naturalHeight, stageWidth, stageHeight } = self.object;
-      const degree = -self.parent.rotation;
-      const natural = self.rotateDimensions({ width: naturalWidth, height: naturalHeight }, degree);
-      const { width, height } = self.rotateDimensions({ width: stageWidth, height: stageHeight }, degree);
-      const { width: radiusX, height: radiusY } = self.rotateDimensions(
-        {
-          width: (self.radiusX * (self.scaleX || 1) * 100) / self.object.stageWidth, //  * (self.scaleX || 1)
-          height: (self.radiusY * (self.scaleY || 1) * 100) / self.object.stageHeight,
-        },
-        degree,
-      );
-
-      const { x, y } = self.rotatePoint(self, degree, false);
-
       const res = {
-        original_width: natural.width,
-        original_height: natural.height,
+        original_width: self.parent.naturalWidth,
+        original_height: self.parent.naturalHeight,
         image_rotation: self.parent.rotation,
         value: {
-          x: (x * 100) / width,
-          y: (y * 100) / height,
-          radiusX,
-          radiusY,
+          x: self.convertXToPerc(self.x),
+          y: self.convertYToPerc(self.y),
+          radiusX: self.convertHDimensionToPerc(self.radiusX),
+          radiusY: self.convertVDimensionToPerc(self.radiusY),
           rotation: self.rotation,
         },
       };

--- a/src/regions/KeyPointRegion.js
+++ b/src/regions/KeyPointRegion.js
@@ -52,6 +52,7 @@ const Model = types
       }
     },
 
+    // @todo not used
     rotate(degree) {
       const p = self.rotatePoint(self, degree);
       self.setPosition(p.x, p.y);
@@ -80,27 +81,16 @@ const Model = types
     },
 
     serialize() {
-      const object = self.object;
-      const { naturalWidth, naturalHeight, stageWidth, stageHeight } = object;
-      const degree = -self.parent.rotation;
-      const natural = self.rotateDimensions({ width: naturalWidth, height: naturalHeight }, degree);
-      const { width, height } = self.rotateDimensions({ width: stageWidth, height: stageHeight }, degree);
-
-      const { x, y } = self.rotatePoint(self, degree, false);
-
-      const res = {
-        original_width: natural.width,
-        original_height: natural.height,
+      return {
+        original_width: self.parent.naturalWidth,
+        original_height: self.parent.naturalHeight,
         image_rotation: self.parent.rotation,
-
         value: {
-          x: (x * 100) / width,
-          y: (y * 100) / height,
-          width: (self.width * 100) / width, //  * (self.scaleX || 1)
+          x: self.convertXToPerc(self.x),
+          y: self.convertYToPerc(self.y),
+          width: self.convertHDimensionToPerc(self.radiusX),
         },
       };
-
-      return res;
     },
   }));
 

--- a/src/regions/KeyPointRegion.js
+++ b/src/regions/KeyPointRegion.js
@@ -88,7 +88,7 @@ const Model = types
         value: {
           x: self.convertXToPerc(self.x),
           y: self.convertYToPerc(self.y),
-          width: self.convertHDimensionToPerc(self.radiusX),
+          width: self.convertHDimensionToPerc(self.width),
         },
       };
     },

--- a/src/regions/PolygonRegion.js
+++ b/src/regions/PolygonRegion.js
@@ -141,6 +141,7 @@ const Model = types
       });
     },
 
+    // @todo not used
     // only px coordtype here
     rotate(degree = -90) {
       self.points.forEach(point => {
@@ -215,30 +216,14 @@ const Model = types
 
     serialize() {
       if (self.points.length < 3) return null;
-
-      const { naturalWidth, naturalHeight, stageWidth, stageHeight } = self.object;
-      const degree = -self.parent.rotation;
-      const natural = self.rotateDimensions({ width: naturalWidth, height: naturalHeight }, degree);
-      const { width, height } = self.rotateDimensions({ width: stageWidth, height: stageHeight }, degree);
-
-      const perc_points = self.points.map(p => {
-        const normalized = self.rotatePoint(p, degree, false);
-        const res_w = (normalized.x * 100) / width;
-        const res_h = (normalized.y * 100) / height;
-
-        return [res_w, res_h];
-      });
-
-      let res = {
-        value: {
-          points: perc_points,
-        },
-        original_width: natural.width,
-        original_height: natural.height,
+      return {
+        original_width: self.parent.naturalWidth,
+        original_height: self.parent.naturalHeight,
         image_rotation: self.parent.rotation,
+        value: {
+          points: self.points.map(p => [self.convertXToPerc(p.x), self.convertYToPerc(p.y)]),
+        },
       };
-
-      return res;
     },
   }));
 

--- a/src/regions/RectRegion.js
+++ b/src/regions/RectRegion.js
@@ -92,6 +92,7 @@ const Model = types
       self.updateAppearenceFromState();
     },
 
+    // @todo not used
     rotate(degree) {
       const p = self.rotatePoint(self, degree);
       if (degree === -90) p.y -= self.width;
@@ -164,35 +165,15 @@ const Model = types
     },
 
     serialize() {
-      const object = self.object;
-      const degree = (360 - self.parent.rotation) % 360;
-      let { x, y } = self.rotatePoint(self, degree, false);
-      if (degree === 270) y -= self.width;
-      if (degree === 90) x -= self.height;
-      if (degree === 180) {
-        x -= self.width;
-        y -= self.height;
-      }
-
-      const natural = self.rotateDimensions({ width: object.naturalWidth, height: object.naturalHeight }, degree);
-      const stage = self.rotateDimensions({ width: object.stageWidth, height: object.stageHeight }, degree);
-      const { width, height } = self.rotateDimensions(
-        {
-          width: (self.width * (self.scaleX || 1) * 100) / object.stageWidth, //  * (self.scaleX || 1)
-          height: (self.height * (self.scaleY || 1) * 100) / object.stageHeight,
-        },
-        degree,
-      );
-
       return {
-        original_width: natural.width,
-        original_height: natural.height,
+        original_width: self.parent.naturalWidth,
+        original_height: self.parent.naturalHeight,
         image_rotation: self.parent.rotation,
         value: {
-          x: (x * 100) / stage.width,
-          y: (y * 100) / stage.height,
-          width,
-          height,
+          x: self.convertXToPerc(self.x),
+          y: self.convertYToPerc(self.y),
+          width: self.convertHDimensionToPerc(self.width),
+          height: self.convertVDimensionToPerc(self.height),
           rotation: self.rotation,
         },
       };

--- a/src/tools/Zoom.js
+++ b/src/tools/Zoom.js
@@ -28,16 +28,14 @@ const ToolView = observer(({ item }) => {
         icon={<ZoomInOutlined />}
         tooltip="Zoom into the image"
         onClick={ev => {
-          // console.log(self.image);
-          // console.log(self._image);
-          item.handleZoom(1.2);
+          item.handleZoom(1);
         }}
       />
       <BasicToolView
         icon={<ZoomOutOutlined />}
         tooltip="Zoom out of the image"
         onClick={ev => {
-          item.handleZoom(0.8);
+          item.handleZoom(-1);
         }}
       />
     </Fragment>
@@ -60,24 +58,15 @@ const _Tool = types
 
     handleDrag(ev) {
       const item = self._manager.obj;
-      const stage = item.stageRef;
-      const scale = stage.scaleX();
-
-      let posx = stage.x() + ev.movementX;
-      let posy = stage.y() + ev.movementY;
-
-      if (posx > 0) posx = 0;
-      if (posy > 0) posy = 0;
-
-      item.setZoom(scale, posx, posy);
-      stage.position({ x: posx, y: posy });
-      stage.batchDraw();
+      let posx = item.zoomingPositionX + ev.movementX;
+      let posy = item.zoomingPositionY + ev.movementY;
+      item.setZoomPosition(posx, posy);
     },
 
     mousemoveEv(ev, [x, y]) {
-      const scale = self._manager.obj.stageRef.scaleX();
+      const zoomScale = self._manager.obj.zoomScale;
 
-      if (scale <= 1) return;
+      if (zoomScale <= 1) return;
       if (self.mode === "moving") self.handleDrag(ev);
     },
 
@@ -85,77 +74,9 @@ const _Tool = types
       self.mode = "moving";
     },
 
-    handleZoom(e, val) {
-      if (e.evt && !e.evt.ctrlKey) {
-        return;
-      } else if (e.evt && e.evt.ctrlKey) {
-        /**
-         * Disable scrolling page
-         */
-        e.evt.preventDefault();
-      }
-
-      // console.log(getEnv(self).manager);
-      // console.log(getEnv(self));
-
+    handleZoom(val) {
       const item = self._manager.obj;
-
-      // const { item } = this.props;
-      item.freezeHistory();
-
-      const stage = item.stageRef;
-      const scaleBy = parseFloat(item.zoomby);
-      const oldScale = stage.scaleX();
-
-      let mousePointTo;
-      let newScale;
-      let pos;
-      let newPos;
-
-      if (e.evt) {
-        mousePointTo = {
-          x: stage.getPointerPosition().x / oldScale - stage.x() / oldScale,
-          y: stage.getPointerPosition().y / oldScale - stage.y() / oldScale,
-        };
-
-        newScale = e.evt.deltaY > 0 ? oldScale * scaleBy : oldScale / scaleBy;
-
-        newPos = {
-          x: -(mousePointTo.x - stage.getPointerPosition().x / newScale) * newScale,
-          y: -(mousePointTo.y - stage.getPointerPosition().y / newScale) * newScale,
-        };
-      } else {
-        pos = {
-          x: stage.width() / 2,
-          y: stage.height() / 2,
-        };
-
-        mousePointTo = {
-          x: pos.x / oldScale - stage.x() / oldScale,
-          y: pos.y / oldScale - stage.y() / oldScale,
-        };
-
-        newScale = Math.max(0.05, oldScale * e);
-
-        newPos = {
-          x: -(mousePointTo.x - pos.x / newScale) * newScale,
-          y: -(mousePointTo.y - pos.y / newScale) * newScale,
-        };
-      }
-
-      if (item.negativezoom !== true && newScale <= 1) {
-        item.setZoom(1, 0, 0);
-        stage.scale({ x: 1, y: 1 });
-        stage.position({ x: 0, y: 0 });
-        stage.batchDraw();
-        return;
-      }
-
-      stage.scale({ x: newScale, y: newScale });
-
-      item.setZoom(newScale, newPos.x, newPos.y);
-      stage.position(newPos);
-      stage.batchDraw();
+      item.handleZoom(val);
     },
   }));
 

--- a/src/utils/canvas.js
+++ b/src/utils/canvas.js
@@ -1,6 +1,8 @@
 import { encode, decode } from "@thi.ng/rle-pack";
 
 import * as Colors from "./colors";
+import { Stage } from "react-konva";
+import React from "react";
 
 // given the imageData object returns the DOM Image with loaded data
 function imageData2Image(imagedata) {
@@ -40,6 +42,7 @@ function Region2RLE(region, image, lineOpts) {
   const nw = image.naturalWidth,
     nh = image.naturalHeight;
   const stage = region.object?.stageRef;
+  const parent = region.parent;
   if (!stage) {
     console.error(`Stage not found for area #${region.cleanId}`);
     return;
@@ -52,6 +55,26 @@ function Region2RLE(region, image, lineOpts) {
   }
   // hide labels on regions and show them later
   layer.find(".region-label").hide();
+
+  const width = stage.getWidth(),
+    height = stage.getHeight(),
+    scaleX = stage.getScaleX(),
+    scaleY = stage.getScaleY(),
+    x = stage.getX(),
+    y = stage.getY(),
+    offsetX = stage.getOffsetX(),
+    offsetY = stage.getOffsetY(),
+    rotation = stage.getRotation();
+  stage
+    .setWidth(parent.stageWidth)
+    .setHeight(parent.stageHeight)
+    .setScaleX(1)
+    .setScaleY(1)
+    .setX(0)
+    .setY(0)
+    .setOffsetX(0)
+    .setOffsetY(0)
+    .setRotation(0);
   stage.drawScene();
   // resize to original size
   const canvas = layer.toCanvas({ pixelRatio: nw / image.stageWidth });
@@ -60,6 +83,16 @@ function Region2RLE(region, image, lineOpts) {
   // get the resulting raw data and encode into RLE format
   const data = ctx.getImageData(0, 0, nw, nh);
   layer.find(".region-label").show();
+  stage
+    .setWidth(width)
+    .setHeight(height)
+    .setScaleX(scaleX)
+    .setScaleY(scaleY)
+    .setX(x)
+    .setY(y)
+    .setOffsetX(offsetX)
+    .setOffsetY(offsetY)
+    .setRotation(rotation);
   stage.drawScene();
   const rle = encode(data.data, data.data.length);
 

--- a/src/utils/utilities.js
+++ b/src/utils/utilities.js
@@ -121,3 +121,7 @@ export function wrapArray(value) {
 export function delay(ms = 0) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export function clamp(x, min, max) {
+  return Math.min(max, Math.max(min, x));
+}


### PR DESCRIPTION
This pull request fixes bugs in rotation.
- regions will no longer lose their shape on rotating and on serialization/deserialization after rotating (especially poligon regions and brush regions)
- zoomed area will stay in place after rotation
- regions will no longer need to follow the image rotation and recalculate positions, which is good for developing of new tools over image