### PR TITLE
Fix multiple labels despite one region when region spans along table columns

### DIFF
--- a/src/mixins/HighlightMixin.js
+++ b/src/mixins/HighlightMixin.js
@@ -47,9 +47,9 @@ export const HighlightMixin = types
 
     updateSpans() {
       if (self._hasSpans) {
-        self._spans.forEach(span => {
-          span.setAttribute("data-label", self.getLabels());
-        });
+        const lastSpan = self._spans[self._spans.length - 1];
+
+        lastSpan.setAttribute("data-label", self.getLabels());
       }
     },
 


### PR DESCRIPTION
Fixes heartexlabs/label-studio#1338.

`updateSpans` is only used in `control/Label.js`.

It fixes problem with `HyperTextLabels` and `HyperText`.
In terms of Code Review, please double check if it won't break any other tags when they are used together with `Label`.