### PR TITLE
Add smart tags

### DIFF
--- a/src/tags/control/Brush.js
+++ b/src/tags/control/Brush.js
@@ -7,6 +7,32 @@ import { AnnotationMixin } from "../../mixins/AnnotationMixin";
 import SeparatedControlMixin from "../../mixins/SeparatedControlMixin";
 import ToolsManager from "../../tools/Manager";
 
+/**
+ * Use the Brush tag for image segmentation tasks where you want to apply a mask or use a brush to draw a region on the image.
+ *
+ * Use with the following data types: image
+ * @example
+ * <!--Basic image segmentation labeling configuration-->
+ * <View>
+ *   <Brush name="labels" toName="image">
+ *     <Label value="Person" />
+ *     <Label value="Animal" />
+ *   </Brush>
+ *   <Image name="image" value="$image" />
+ * </View>
+ * @name Brush
+ * @regions BrushRegion
+ * @meta_title Brush Tag for Image Segmentation Labeling
+ * @meta_description Customize Label Studio with brush tags for image segmentation labeling for machine learning and data science projects.
+ * @param {string} name                      - Name of the element
+ * @param {string} toName                    - Name of the image to label
+ * @param {single|multiple=} [choice=single] - Configure whether the data labeler can select one or multiple labels
+ * @param {number} [maxUsages]               - Maximum number of times a label can be used per task
+ * @param {boolean} [showInline=true]        - Show labels in the same visual line
+ * @param {boolean} [smart]                  - Show smart tool for interactive pre-annotations
+ * @param {boolean} [smartOnly]              - Only show smart tool for interactive pre-annotations
+ */
+
 const TagAttrs = types.model({
   name: types.identifier,
   toname: types.maybeNull(types.string),

--- a/src/tags/control/Ellipse.js
+++ b/src/tags/control/Ellipse.js
@@ -28,6 +28,8 @@ import ToolsManager from "../../tools/Manager";
  * @param {string} [strokeColor=#f48a42] - Stroke color in hexadecimal
  * @param {number} [strokeWidth=1]       - Width of the stroke
  * @param {boolean} [canRotate=true]     - Show or hide rotation control
+ * @param {boolean} [smart]              - Show smart tool for interactive pre-annotations
+ * @param {boolean} [smartOnly]          - Only show smart tool for interactive pre-annotations
  */
 const TagAttrs = types.model({
   name: types.identifier,

--- a/src/tags/control/KeyPoint.js
+++ b/src/tags/control/KeyPoint.js
@@ -26,6 +26,8 @@ import ToolsManager from "../../tools/Manager";
  * @param {string=} [fillColor=#8bad00]  - Keypoint fill color in hexadecimal
  * @param {number=} [strokeWidth=1]      - Width of the stroke
  * @param {string=} [strokeColor=#8bad00] - Keypoint stroke color in hexadecimal
+ * @param {boolean} [smart]              - Show smart tool for interactive pre-annotations
+ * @param {boolean} [smartOnly]          - Only show smart tool for interactive pre-annotations
  */
 const TagAttrs = types.model({
   name: types.identifier,

--- a/src/tags/control/Labels/Labels.js
+++ b/src/tags/control/Labels/Labels.js
@@ -41,8 +41,6 @@ import "../Label";
  * @param {string=} [fillColor]              - Rectangle fill color in hexadecimal
  * @param {string=} [strokeColor=#f48a42]    - Stroke color in hexadecimal
  * @param {number=} [strokeWidth=1]          - Width of the stroke
- * @param {boolean} [smart]                  - Show smart tool for interactive pre-annotations
- * @param {boolean} [smartOnly]              - Only show smart tool for interactive pre-annotations
  */
 const TagAttrs = types.model({
   name: types.identifier,

--- a/src/tags/control/Labels/Labels.js
+++ b/src/tags/control/Labels/Labels.js
@@ -41,6 +41,8 @@ import "../Label";
  * @param {string=} [fillColor]              - Rectangle fill color in hexadecimal
  * @param {string=} [strokeColor=#f48a42]    - Stroke color in hexadecimal
  * @param {number=} [strokeWidth=1]          - Width of the stroke
+ * @param {boolean} [smart]                  - Show smart tool for interactive pre-annotations
+ * @param {boolean} [smartOnly]              - Only show smart tool for interactive pre-annotations
  */
 const TagAttrs = types.model({
   name: types.identifier,

--- a/src/tags/control/Pairwise.js
+++ b/src/tags/control/Pairwise.js
@@ -7,12 +7,13 @@ import { AnnotationMixin } from "../../mixins/AnnotationMixin";
 import ControlBase from "./Base";
 
 /**
- * Use the Pairwise tag to compare two different objects.
+ * Use the Pairwise tag to compare two different objects and select one item from the list. If you want annotators to compare two objects and determine whether they are similar or not, use the Choices tag.
  *
  * Use with the following data types: audio, image, HTML, paragraphs, text, time series, video
  * @example
  * <!--Basic labeling configuration to compare two passages of text -->
  * <View>
+ *   <Header value="Select the more accurate summary"/>
  *   <Pairwise name="pairwise" leftClass="text1" rightClass="text2" toName="txt-1,txt-2"></Pairwise>
  *   <Text name="txt-1" value="Text 1" />
  *   <Text name="txt-2" value="Text 2" />

--- a/src/tags/control/Polygon.js
+++ b/src/tags/control/Polygon.js
@@ -30,6 +30,8 @@ import ToolsManager from "../../tools/Manager";
  * @param {number} [strokeWidth=3]                - Width of stroke
  * @param {small|medium|large} [pointSize=small]  - Size of polygon handle points
  * @param {rectangle|circle} [pointStyle=circle]  - Style of points
+ * @param {boolean} [smart]                       - Show smart tool for interactive pre-annotations
+ * @param {boolean} [smartOnly]                   - Only show smart tool for interactive pre-annotations
  */
 const TagAttrs = types.model({
   name: types.identifier,

--- a/src/tags/control/Rectangle.js
+++ b/src/tags/control/Rectangle.js
@@ -28,6 +28,8 @@ import ToolsManager from "../../tools/Manager";
  * @param {string=} [strokeColor=#f48a42] - Stroke color in hexadecimal
  * @param {number=} [strokeWidth=1]       - Width of the stroke
  * @param {boolean=} [canRotate=true]     - Whether to show or hide rotation control
+ * @param {boolean} [smart]               - Show smart tool for interactive pre-annotations
+ * @param {boolean} [smartOnly]           - Only show smart tool for interactive pre-annotations
  */
 const TagAttrs = types.model({
   name: types.identifier,


### PR DESCRIPTION
@hlomzik please check that I added this correctly and didn't miss any tags or defaults.
Also, I added docs for the Brush tag since that is supported independently.

- Added docs for the Brush tag
- Added the "smart" and "smartOnly" parameters to Brush, Ellipse, KeyPoint, Polygon, Rectangle tags
- Update the Pairwise tag with additional details (separate from smart tags).