### PR TITLE
[fix] check whenLabelValue=A,B for required also

### DIFF
--- a/src/mixins/AreaMixin.js
+++ b/src/mixins/AreaMixin.js
@@ -33,7 +33,15 @@ export const AreaMixin = types
     },
 
     hasLabel(value) {
-      return self.labeling?.mainValue?.includes(value);
+      const labels = self.labeling?.mainValue;
+
+      if (!labels) return false;
+      // label can contain comma, so check for full match first
+      if (labels.includes(value)) return true;
+      if (value.includes(",")) {
+        return value.split(",").some(v => labels.includes(v));
+      }
+      return false;
     },
 
     get perRegionTags() {


### PR DESCRIPTION
Given config should warn when checkbox for A or B is unchecked and should pass for C.

Current behaviour: doesn't warn.

```
<View>
    <Text name="text" value="$text" />
    <Labels name="ner" toName="text">
        <Label value="A"/>
        <Label value="B"/>
        <Label value="C"/>
    </Labels>
    <Choices visibleWhen="region-selected" whenLabelValue="A,B" name="ch" toName="text" required="true" perRegion="true">
        <Choice value="one"/>
        <Choice value="two"/>
    </Choices>
</View>```