### PR TITLE
fix: DEV-1220: fix HTML misplacements

### DIFF
--- a/src/stores/AnnotationStore.js
+++ b/src/stores/AnnotationStore.js
@@ -840,7 +840,7 @@ const Annotation = types
         });
       }
 
-      self.objects.forEach(obj => obj.needsUpdate?.());
+      self.updateObjects();
     },
 
     /**

--- a/src/stores/AnnotationStore.js
+++ b/src/stores/AnnotationStore.js
@@ -1332,7 +1332,8 @@ export default types
 
       selectAnnotation(c.id);
       c.deserializeResults(s);
-      c.updateObjects();
+      // reinit will trigger `updateObjects()` so we omit it here
+      c.reinitHistory();
 
       // parent link for the new annotations
       if (entity.pk) {

--- a/src/tags/object/RichText/view.js
+++ b/src/tags/object/RichText/view.js
@@ -260,6 +260,8 @@ class RichTextPieceView extends Component {
     // @todo both loops should be merged to fix old broken xpath using "dirty" html
     if (initial) {
       item.initGlobalOffsets(root);
+      // lot of changes possibly made during regions preparation, so clear the history
+      item.annotation.reinitHistory();
     }
 
     // Apply highlight to ranges of a current tag

--- a/src/utils/selection-tools.js
+++ b/src/utils/selection-tools.js
@@ -1,4 +1,4 @@
-import { clamp } from "./utilities";
+import { clamp, isDefined } from "./utilities";
 
 const isTextNode = node => node && node.nodeType === Node.TEXT_NODE;
 
@@ -685,7 +685,7 @@ const findGlobalOffset = (node, position, root) => {
     }
 
     if (isText || isBR) {
-      let length = currentNode.length ?? 1;
+      let length = isDefined(currentNode.length) ? [...currentNode.textContent].length : 1;
 
       if (atTargetNode) {
         length = Math.min(position, length);


### PR DESCRIPTION
- [x] html starts with some changes in history already
  - this causes draft creation in 5 sec after task loaded
  - if there was a draft undo would switch to original task state
  - if there was no drafts undo would not change anything
- [x] offsets are broken after emoji
  - try to create region in a text after emoji — it will be shifted
  - reload page — it'll be shifted more