### PR TITLE
add events for creation, deletion and label updates of relations

### DIFF
--- a/src/components/Relations/Relations.js
+++ b/src/components/Relations/Relations.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, List, Select } from "antd";
-import { getRoot, isValidReference } from "mobx-state-tree";
+import { getEnv, getRoot, isValidReference } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import { ArrowLeftOutlined, ArrowRightOutlined, DeleteOutlined, MoreOutlined, SwapOutlined } from "@ant-design/icons";
 
@@ -18,6 +18,7 @@ const { Option } = Select;
 const RelationMeta = observer(({ rl }) => {
   const r = rl.relations;
   const selected = r.getSelected().map(v => v.value);
+  const events = getEnv(rl).events;
 
   return (
     <div style={{ marginTop: "10px" }}>
@@ -32,6 +33,7 @@ const RelationMeta = observer(({ rl }) => {
 
           r.unselectAll();
           values.forEach(v => r.findRelation(v).setSelected(true));
+          events.invoke('selectRelationLabels', rl);
         }}
       >
         {r.children.map(c => (

--- a/src/stores/RelationStore.js
+++ b/src/stores/RelationStore.js
@@ -1,4 +1,4 @@
-import { destroy, getParentOfType, getRoot, isValidReference, types } from "mobx-state-tree";
+import { destroy, getEnv, getParentOfType, getRoot, isValidReference, types } from "mobx-state-tree";
 
 import { cloneNode, guidGenerator } from "../core/Helpers";
 import { RelationsModel } from "../tags/control/Relations";
@@ -126,12 +126,14 @@ const RelationStore = types
 
       // self.relations.unshift(rl);
       self._relations.push(rl);
+      getEnv(self).events.invoke('addRelation', rl);
 
       return rl;
     },
 
     deleteRelation(rl) {
       destroy(rl);
+      getEnv(self).events.invoke('deleteRelation', rl);
     },
 
     deleteNodeRelation(node) {


### PR DESCRIPTION
Hi, 

i'm trying to embed LSF into a custom application which works fine. I need to be able to recognize operations such as creation and deletion of regions and their relations. This already works for regions, but there are no events broadcast yet for relations. Hence this PR adds events for:

- Creating relations, topic: "addRelation"
- Deleting relations, topic: "deleteRelation"
- Selecting labels of a relation, topic: "selectRelationLabels"

These events are especially helpful if the embedding application wants to:

- maintain an 'isDirty' state, hence did any relation or entity change or got created / deleted
- e.g. to make a label mandatory for every relation, the callback for "addRelation" can be used to display a dialog so the user has to select a label (and then set it by 'relation.relations.children[userSelectedIndex].selected = true').

I could not spot any tests yet for the existing events, if you can point me into the right direction i could also try to provide tests to verify the events are actually broadcasted. 

Greetings,
Alex