### PR TITLE
fix: DEV-1324: fix undo/redo for Audio

### DIFF
--- a/src/regions/AudioRegion.js
+++ b/src/regions/AudioRegion.js
@@ -28,6 +28,8 @@ const Model = types
     },
 
     wsRegionElement(wsRegion) {
+      if (!wsRegion) return null;
+
       const elID = wsRegion.id;
       const el = document.querySelector(`[data-id="${elID}"]`);
 
@@ -91,6 +93,8 @@ const Model = types
 
     updateAppearenceFromState() {
       if (self._ws_region?.update) {
+        self._ws_region.start = self.start;
+        self._ws_region.end = self.end;
         self.applyCSSClass(self._ws_region);
       }
     },


### PR DESCRIPTION
- undo doesn't work for audio
  - if there was a draft, moved region will disappear after undo
  - if there was no drafts, nothing happens
- redo do nothing for audio (connected with previous)