### PR TITLE
fix: DEV-23: show line numbers again for Text

### DIFF
--- a/e2e/fragments/AtRichText.js
+++ b/e2e/fragments/AtRichText.js
@@ -30,6 +30,6 @@ module.exports = {
     return locate(this._rootSelector);
   },
   locateText(locator) {
-    return locate(this.locate(locator).toXPath() + "/text()");
+    return locate(this.locate(locator).toXPath() + "//text()");
   },
 };

--- a/e2e/helpers/Selection.js
+++ b/e2e/helpers/Selection.js
@@ -6,7 +6,7 @@ class Selection extends Helper {
     const { Puppeteer } = this.helpers;
     const { page } = Puppeteer;
     const { mouse } = page;
-    const xpath = [locate(parent).toXPath(),`/text()[contains(., '${text}')]`,"[last()]"].join("");
+    const xpath = [locate(parent).toXPath(),`//text()[contains(., '${text}')]`,"[last()]"].join("");
     const textEls = await page.$x(xpath);
     const point = await page.evaluate((textEl, text)=>{
       const pos = textEl.wholeText.search(text);

--- a/e2e/tests/regression-tests/richtext.test.js
+++ b/e2e/tests/regression-tests/richtext.test.js
@@ -110,6 +110,7 @@ Scenario("Trim spaces around the word", async ({ I, LabelStudio, AtSidebar, AtRi
     assert.fail(`Got an error: ${errors[0]}`);
   }
 });
+
 Scenario("Trim spaces with BRs", async ({ I, LabelStudio, AtSidebar, AtRichText, ErrorsCollector }) => {
   I.amOnPage("/");
   await ErrorsCollector.run();
@@ -152,7 +153,7 @@ Scenario("Overlap checks", async ({ I, LabelStudio, AtSidebar, AtRichText, Error
   AtSidebar.see("Half");
   I.pressKey("1");
   AtRichText.selectTextByGlobalOffset(4,8);
-  I.seeNumberOfElements(AtRichText.locate("span"), 2);
+  I.seeNumberOfElements(AtRichText.locate("span.htx-highlight"), 2);
   const errors = await ErrorsCollector.grabErrors();
 
   if (errors.length) {

--- a/src/components/Entities/Entities.scss
+++ b/src/components/Entities/Entities.scss
@@ -18,12 +18,16 @@
     align-items: center;
     display: flex;
     flex-wrap: nowrap;
+    margin-bottom: 12px;
+  }
+
+  .ant-tree-draggable-icon {
+    width: 14px;
+    flex-shrink: 0;
   }
 
   .ant-tree .ant-tree-node-content-wrapper {
     padding: 0;
-    margin-bottom: 12px;
-    transition: margin-bottom 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
   }
 
   .ant-tree .ant-tree-node-content-wrapper.ant-tree-node-selected,

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -119,7 +119,8 @@ const SettingsModel = types
 
       // hack to enable it from outside, because Text spawns spans on every rerender
       // @todo it should be enabled inside Text
-      document.querySelectorAll(".htx-text").forEach(text => text.classList.toggle("htx-line-numbers"));
+      document.querySelectorAll(".lsf-htx-richtext")
+        .forEach(text => text.dataset.linenumbers = self.showLineNumbers ? "enabled" : "disabled");
     },
 
     toggleContinuousLabeling() {

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -116,11 +116,6 @@ const SettingsModel = types
 
     toggleShowLineNumbers() {
       self.showLineNumbers = !self.showLineNumbers;
-
-      // hack to enable it from outside, because Text spawns spans on every rerender
-      // @todo it should be enabled inside Text
-      document.querySelectorAll(".lsf-htx-richtext")
-        .forEach(text => text.dataset.linenumbers = self.showLineNumbers ? "enabled" : "disabled");
     },
 
     toggleContinuousLabeling() {

--- a/src/tags/object/RichText/RichText.styl
+++ b/src/tags/object/RichText/RichText.styl
@@ -58,7 +58,7 @@
         text-align right
         z-index 1
 
-      &:last-child:&::before
+      &:last-child::before
         min-height 1em // to not overgrow container's height
 
       &:hover,

--- a/src/tags/object/RichText/RichText.styl
+++ b/src/tags/object/RichText/RichText.styl
@@ -32,6 +32,43 @@
     background: rgba(125,125,125,.15);
     font-size: 24px;
 
+  &__container[data-linenumbers=enabled]
+    padding-left 3em // 3em for line numbers
+    counter-reset line-number
+
+    :global(span.line)
+      position relative // to position line numbers
+      display inline-block // for alignment and hover highlight
+      min-height 1.2em // for styling numbers for empty lines
+      padding-left 8px
+
+      &::before
+        counter-increment line-number
+        content counter(line-number)
+        position absolute
+        top 0
+        left -3em
+        height 100%
+        min-height 2.2em // for straight separator even on empty lines (they have wrong height)
+        width 3em // for 4 digits
+        border-right 1px solid lightgray
+        padding-right 4px
+        font-size 0.8em
+        line-height 2em // = 1.6em as usual text
+        text-align right
+        z-index 1
+
+      &:last-child:&::before
+        min-height 1em // to not overgrow container's height
+
+      &:hover,
+      &:hover::before
+        background #f4f4f4
+
+      &:empty
+        background none // empty lines have broken height and almost zero width, so don't highlight
+
+
 // global.scss is not included to final build, so define it here
 :global(.htx-no-label)::after {
   display: none;

--- a/src/tags/object/RichText/RichText.styl
+++ b/src/tags/object/RichText/RichText.styl
@@ -36,7 +36,7 @@
     padding-left 3em // 3em for line numbers
     counter-reset line-number
 
-    :global(span.line)
+    ~/__line
       position relative // to position line numbers
       display inline-block // for alignment and hover highlight
       min-height 1.2em // for styling numbers for empty lines

--- a/src/tags/object/RichText/view.js
+++ b/src/tags/object/RichText/view.js
@@ -391,12 +391,16 @@ class RichTextPieceView extends Component {
 
     if (!item._value) return null;
 
-    const content = item._value || "";
+    let val = item._value || "";
     const newLineReplacement = "<br/>";
+    const settings = this.props.store.settings;
 
-    const val = item.type === 'text'
-      ? htmlEscape(content).replace(/\n|\r/g, newLineReplacement)
-      : content;
+    if (item.type === 'text') {
+      val = htmlEscape(val)
+        .split(/\n|\r/g)
+        .map(s => `<span class="line">${s}</span>`)
+        .join(newLineReplacement);
+    }
 
     if (item.inline) {
       const eventHandlers = {
@@ -419,6 +423,7 @@ class RichTextPieceView extends Component {
               this.setReady(false);
               this.rootNodeRef.current = el;
             }}
+            data-linenumbers={settings.showLineNumbers ? "enabled" : "disabled"}
             className="htx-richtext"
             dangerouslySetInnerHTML={{ __html: val }}
             {...eventHandlers}

--- a/src/tags/object/RichText/view.js
+++ b/src/tags/object/RichText/view.js
@@ -8,7 +8,7 @@ import { fixCodePointsInRange } from "../../../utils/selection-tools";
 import "./RichText.styl";
 import { isAlive } from "mobx-state-tree";
 import { LoadingOutlined } from "@ant-design/icons";
-import { Block, Elem } from "../../../utils/bem";
+import { Block, cn, Elem } from "../../../utils/bem";
 import { observe } from "mobx";
 
 class RichTextPieceView extends Component {
@@ -394,11 +394,14 @@ class RichTextPieceView extends Component {
     let val = item._value || "";
     const newLineReplacement = "<br/>";
     const settings = this.props.store.settings;
+    const isText = item.type === 'text';
 
-    if (item.type === 'text') {
+    if (isText) {
+      const cnLine = cn("richtext", { elem: "line" });
+
       val = htmlEscape(val)
         .split(/\n|\r/g)
-        .map(s => `<span class="line">${s}</span>`)
+        .map(s => `<span class="${cnLine}">${s}</span>`)
         .join(newLineReplacement);
     }
 
@@ -423,7 +426,7 @@ class RichTextPieceView extends Component {
               this.setReady(false);
               this.rootNodeRef.current = el;
             }}
-            data-linenumbers={settings.showLineNumbers ? "enabled" : "disabled"}
+            data-linenumbers={isText && settings.showLineNumbers ? "enabled" : "disabled"}
             className="htx-richtext"
             dangerouslySetInnerHTML={{ __html: val }}
             {...eventHandlers}


### PR DESCRIPTION
Show them again if such setting enabled.
Uses `data-linenumbers` attribute to store current setting.

Also fix region items appearance in sidebar list.