### PR TITLE
fix: DEV-1760: styles override for spans and links

### DIFF
--- a/src/mixins/HighlightMixin.js
+++ b/src/mixins/HighlightMixin.js
@@ -264,7 +264,7 @@ const createSpanStylesheet = (document, identifier, color) => {
 
   const rules = {
     [className]: `
-      background-color: var(${variables.color});
+      background-color: var(${variables.color}) !important;
       cursor: var(${variables.cursor}, pointer);
       border: 1px dashed transparent;
     `,
@@ -278,7 +278,7 @@ const createSpanStylesheet = (document, identifier, color) => {
       line-height: 0;
     `,
     [classNames.active]: `
-      color: ${Utils.Colors.contrastColor(initialActiveColor)};
+      color: ${Utils.Colors.contrastColor(initialActiveColor)} !important;
       ${variables.color}: ${initialActiveColor}
     `,
     [classNames.highlighted]: `

--- a/src/tags/object/RichText/view.js
+++ b/src/tags/object/RichText/view.js
@@ -108,7 +108,7 @@ class RichTextPieceView extends Component {
       this._selectionMode = false;
       return;
     }
-    if (!this.props.item.clickablelinks && matchesSelector(event.target, "a")) {
+    if (!this.props.item.clickablelinks && matchesSelector(event.target, "a[href]")) {
       event.preventDefault();
       return;
     }
@@ -325,7 +325,7 @@ class RichTextPieceView extends Component {
     // fix unselectable links
     const style = doc.createElement("style");
 
-    style.textContent = "body a { pointer-events: all; }";
+    style.textContent = "body a[href] { pointer-events: all; }";
     doc.head.appendChild(style);
 
     // // @todo make links selectable; dragstart supressing doesn't help — they are still draggable

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -419,7 +419,7 @@ function applyHighlightStylesToDoc(destDoc, rulesByStyleId) {
 }
 
 /**
- * Checks if element of one of it's descendants match given selector
+ * Checks if element or one of its descendants match given selector
  * @param {HTMLElement} element Element to match
  * @param {string} selector CSS selector
  */


### PR DESCRIPTION
1. highest priority for LSF spans' styles, so page styles won't affect them
2. `<a>` without `href` should not be disabled