### PR TITLE
hotfix 2.1.5: Taxonomy width is auto adjustable  (#551)

### DIFF
--- a/src/components/Taxonomy/Taxonomy.module.scss
+++ b/src/components/Taxonomy/Taxonomy.module.scss
@@ -63,9 +63,6 @@
   background: white;
   border-radius: 6px;
   left: -1px;
-  width: max-content;
-  min-width: 100%;
-  max-width: 50vw; // 100% is not enough
   border: 1px solid #e2e2e2;
   box-shadow: 0 4px 10px rgb(0 0 0 / 12%);
 
@@ -126,6 +123,9 @@
 }
 
 .taxonomy__item label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   flex-grow: 1;
   flex-shrink: 0;
   line-height: 2em;
@@ -158,18 +158,25 @@
   padding: 0 12px;
   min-width: 40px; // 24px padding + 16px width for count/dots
   text-align: right;
+  position: relative; // important for wide labels to not overlap counts with label
 
   &_actions {
-    display: none;
+    visibility: hidden;
+    display: block;
     font-weight: bold;
     cursor: pointer;
     text-align: center;
   }
-
+  .taxonomy__item &_count:not(:last-child) {
+    position: absolute;
+    right: 12px;
+  }
   .taxonomy__item:hover &_count:not(:last-child) {
+    visibility: hidden;
     display: none;
   }
   .taxonomy__item:hover &_actions {
+    visibility: visible;
     display: block;
   }
 }

--- a/src/components/Taxonomy/Taxonomy.tsx
+++ b/src/components/Taxonomy/Taxonomy.tsx
@@ -25,6 +25,8 @@ type TaxonomyOptions = {
   showFullPath?: boolean,
   pathSeparator?: string,
   maxUsages?: number,
+  maxWidth?: number,
+  minWidth?: number,
   placeholder?: string,
 };
 
@@ -56,10 +58,7 @@ type UserLabelFormProps = {
 
 interface RowProps {
   style: any;
-  index: number;
-  data: (
-    index: number,
-  ) => {
+  item: {
     row: {
       id: string,
       isOpen: boolean,
@@ -75,6 +74,7 @@ interface RowProps {
     toggle: (id: string) => void,
     addInside: (id?: string) => void,
   };
+  atMaxWidth: boolean;
 }
 
 const UserLabelForm = ({ onAddLabel, onFinish, path }: UserLabelFormProps) => {
@@ -133,9 +133,7 @@ function isSubArray(item: string[], parent: string[]) {
   return parent.every((n, i) => item[i] === n);
 }
 
-const Item: React.FC<RowProps> = (props: RowProps) => {
-  const { style, data, index } = props;
-  const item = data(index);
+const Item: React.FC<RowProps> = ({ style, item }: RowProps) => {
   const {
     row: { id, isOpen, childCount, isFiltering, name, path, padding, isLeaf },
     toggle,
@@ -190,7 +188,11 @@ const Item: React.FC<RowProps> = (props: RowProps) => {
           <div className={styles.taxonomy__grouping} onClick={() => toggle(id)}>
             <LsChevron stroke="#09f" style={arrowStyle} />
           </div>
-          <label onClick={onClick} title={title} className={disabled ? styles.taxonomy__collapsable : undefined}>
+          <label
+            onClick={onClick}
+            title={title}
+            className={disabled ? styles.taxonomy__collapsable : undefined}
+          >
             <input
               type="checkbox"
               disabled={disabled}
@@ -291,7 +293,7 @@ const TaxonomyDropdown = ({ show, flatten, items, dropdownRef }: TaxonomyDropdow
   const [search, setSearch] = useState("");
   const predicate = (item: TaxonomyItem) => item.label.toLocaleLowerCase().includes(search);
   const onInput = (e: FormEvent<HTMLInputElement>) => setSearch(e.currentTarget.value.toLocaleLowerCase());
-  const { onAddLabel } = useContext(TaxonomyOptionsContext);
+  const { onAddLabel, minWidth, maxWidth } = useContext(TaxonomyOptionsContext);
   const [isAdding, addInside, closeForm] = useToggle(false);
 
   const list = search ? filterTreeByPredicate(flatten, predicate) : items;
@@ -349,7 +351,8 @@ const TaxonomyDropdown = ({ show, flatten, items, dropdownRef }: TaxonomyDropdow
           rowHeight={30}
           defaultExpanded={false}
           maxHeightPercentage={50}
-          minWidth={300}
+          minWidth={Number(minWidth) || 200}
+          maxWidth={Number(maxWidth) || 600}
           transformationCallback={dataTransformation}
         />
       )}

--- a/src/components/TreeStructure/TreeStructure.tsx
+++ b/src/components/TreeStructure/TreeStructure.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useRef, useState } from "react";
+import React, { RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { FixedSizeList } from "react-window";
 
 type ExtendedData = Readonly<{
@@ -58,6 +58,8 @@ const countChildNodes = (item: RowItem[]) => {
 
 const blankItem = (path: string[], depth: number): RowItem => ({ label: "", depth, path, isOpen: true });
 
+
+
 const TreeStructure = ({
   items,
   rowComponent,
@@ -65,6 +67,7 @@ const TreeStructure = ({
   rowHeight,
   maxHeightPercentage,
   minWidth,
+  maxWidth,
   transformationCallback,
   defaultExpanded,
 }: {
@@ -74,6 +77,7 @@ const TreeStructure = ({
   rowHeight: number,
   maxHeightPercentage: number,
   minWidth: number,
+  maxWidth: number,
   defaultExpanded: boolean,
   transformationCallback: transformationCallback,
 }) => {
@@ -82,6 +86,7 @@ const TreeStructure = ({
   const [data, setData] = useState<ExtendedData[]>();
   const [openNodes, setOpenNodes] = useState<{ [key: string]: number }>({});
   const [height, setHeight] = useState(0);
+  const [width, setWidth] = useState(minWidth);
   const containerRef = useRef<RefObject<HTMLDivElement> | any>();
 
   const calcHeight = () => {
@@ -92,6 +97,7 @@ const TreeStructure = ({
   };
 
   const updateHeight = () => setHeight(calcHeight());
+
 
   const toggle = (id: string) => {
     const toggleItem = defaultExpanded
@@ -113,6 +119,49 @@ const TreeStructure = ({
     updateHeight();
   };
 
+  const Row = ({
+    data: dataGetter,
+    index,
+    rowStyle: style,
+    rowComponent: RowComponent,
+  }: {
+    data: (
+      index: number,
+    ) => {
+      row:
+      | Readonly<{
+        id: string,
+        isLeaf: boolean,
+        name: string,
+        nestingLevel: number,
+        padding: number,
+        path: string[],
+      }>
+      | undefined,
+    },
+    index: number,
+    rowStyle: any,
+    rowComponent: React.FC<any>,
+  }) => {
+    const rowRef = useRef<RefObject<HTMLDivElement> | any>();
+
+    useEffect(() => {
+      const itemWidth = rowRef.current?.firstChild?.scrollWidth;
+
+      if (width < itemWidth) {
+        if (maxWidth < itemWidth) {
+          setWidth(maxWidth);
+        } else setWidth(itemWidth);
+      }
+    }, []);
+    const item = dataGetter(index);
+
+    return (
+      <div ref={rowRef}>
+        <RowComponent {...{ item, style }} />
+      </div>
+    );
+  };
   const recursiveTreeWalker = ({
     items,
     depth,
@@ -163,17 +212,16 @@ const TreeStructure = ({
   useEffect(() => updateHeight(), [data]);
 
   return (
-    <div ref={containerRef}>
-      <FixedSizeList
-        height={height}
-        itemCount={data?.length || 0}
-        itemSize={rowHeight}
-        width={containerRef?.current?.offsetWidth || minWidth}
-        itemData={(index: number) => ({ row: data && data[index], toggle, addInside })}
-      >
-        {rowComponent}
-      </FixedSizeList>
-    </div>
+    <FixedSizeList
+      ref={containerRef}
+      height={height}
+      itemCount={data?.length || 0}
+      itemSize={rowHeight}
+      width={width}
+      itemData={(index: number) => ({ row: data && data[index], toggle, addInside })}
+    >
+      {({ data, index, style }) => <Row data={data} rowStyle={style} index={index} rowComponent={rowComponent} />}
+    </FixedSizeList>
   );
 };
 

--- a/src/tags/control/Taxonomy.js
+++ b/src/tags/control/Taxonomy.js
@@ -44,6 +44,8 @@ import { FF_DEV_2007_DEV_2008, isFF } from "../../utils/feature-flags";
  * @param {boolean} [showFullPath=false] - Whether to show the full path of selected items
  * @param {string} [pathSeparator= / ] - Separator to show in the full path
  * @param {number} [maxUsages]         - Maximum number of times a choice can be selected per task
+ * @param {number} [maxWidth]         - Maximum width for dropdown
+ * @param {number} [minWidth]         - Minimum width for dropdown
  * @param {boolean} [required=false]   - Whether taxonomy validation is required
  * @param {string} [requiredMessage]   - Message to show if validation fails
  * @param {string} [placeholder=]      - What to display as prompt on the input
@@ -55,6 +57,8 @@ const TagAttrs = types.model({
   showfullpath: types.optional(types.boolean, false),
   pathseparator: types.optional(types.string, " / "),
   placeholder: "",
+  minwidth: types.maybeNull(types.string),
+  maxwidth: types.maybeNull(types.string),
   maxusages: types.maybeNull(types.string),
   ...(isFF(FF_DEV_2007_DEV_2008) ? { value: types.optional(types.string, "") } : {}),
 });
@@ -226,6 +230,8 @@ const HtxTaxonomy = observer(({ item }) => {
     leafsOnly: item.leafsonly,
     pathSeparator: item.pathseparator,
     maxUsages: item.maxusages,
+    maxWidth: item.maxwidth,
+    minWidth: item.minwidth,
     placeholder: item.placeholder,
   };
 


### PR DESCRIPTION
* calcualte row width based on the biggest visible taxonomy item

* resolve max width with elepisis

* add min and max width to config options

* mad typo

* fix min/maxWidth parameters for Taxonomy

* will scroll if beyond maximum width

* scroll if too wide

* fix extra block for long labels

Co-authored-by: Travis Clark <“travisjosephclark@gmail.com”>
Co-authored-by: hlomzik <hlomzik@gmail.com>