### PR TITLE
fix: DEV-2120: required Number with default value

### DIFF
--- a/src/tags/control/Number.js
+++ b/src/tags/control/Number.js
@@ -90,9 +90,29 @@ const Model = types
     },
 
     beforeSend() {
-      // add defaultValue to results for top-level controls
-      if (!isDefined(self.number) && isDefined(self.defaultvalue) && !self.perRegion) {
-        self.setNumber(+self.defaultvalue);
+      if (!isDefined(self.defaultvalue)) return;
+
+      // let's fix only required perRegions
+      if (self.perregion && self.required) {
+        const object = self.annotation.names.get(self.toname);
+
+        for (const reg of object?.regs ?? []) {
+          // add result with default value to every region of related object without number yet
+          if (!reg.results.some(r => r.from_name === self)) {
+            reg.results.push({
+              area: reg,
+              from_name: self,
+              to_name: object,
+              type: self.resultType,
+              value: {
+                [self.valueType]: +self.defaultvalue,
+              },
+            });
+          }
+        }
+      } else {
+        // add defaultValue to results for top-level controls
+        if (!isDefined(self.number)) self.setNumber(+self.defaultvalue);
       }
     },
 


### PR DESCRIPTION
There are no results if user didn't touch Number,
but if there is defaultValue we should create a new result
with it on the fly for every region.
That works only for required perRegion Number with no value added.