### PR TITLE
fix: DEV-2408: Regions disappearing from UI

### DIFF
--- a/e2e/tests/regression-tests/wrong-results-order.test.js
+++ b/e2e/tests/regression-tests/wrong-results-order.test.js
@@ -1,0 +1,50 @@
+/* global Feature, Scenario */
+
+Feature("Wrong ordered results deserialization").tag("@regress");
+
+Scenario("Combining results of per-region  textarea and richtext regions.", async ({ I, LabelStudio, AtSidebar }) => {
+  I.amOnPage("/");
+
+  LabelStudio.init({
+    annotations: [
+      {
+        id: "test", result: [
+
+          {
+            id: "id_1",
+            from_name: "comment",
+            to_name: "text",
+            type: "textarea",
+            value: {
+              start: 0,
+              end: 11,
+              text: ["That's true"],
+            },
+          },
+          {
+            id: "id_1",
+            from_name: "labels",
+            to_name: "text",
+            type: "labels",
+            value: {
+              start: 0,
+              end: 11,
+              labels: ["Label 1"],
+              text: "Just a text",
+            },
+          },
+        ],
+      }],
+    config: `
+<View>
+  <Labels name="labels" toname="text">
+    <Label value="Label 1"/>
+  </Labels>
+  <Text name="text" value="$text"  />
+  <Textarea name="comment" toname="text" perregion="true"/>
+</View>`,
+    data: { text: "Just a text" },
+  });
+
+  AtSidebar.seeRegions(1);
+});

--- a/src/stores/Annotation/Annotation.js
+++ b/src/stores/Annotation/Annotation.js
@@ -14,6 +14,7 @@ import Area from "../../regions/Area";
 import throttle from "lodash.throttle";
 import { UserExtended } from "../UserStore";
 import { FF_DEV_2100, FF_DEV_2100_A, isFF } from "../../utils/feature-flags";
+import Result from "../../regions/Result";
 
 const hotkeys = Hotkey("Annotations", "Annotations");
 
@@ -951,6 +952,15 @@ export const Annotation = types
         const areaId = `${id || guidGenerator()}#${self.id}`;
         const resultId = `${data.from_name}@${areaId}`;
         const value = self.prepareValue(rawValue, tagType);
+        // This should fix a problem when the order of results is broken
+        const omitValueFields = (value) => {
+          const newValue = { ...value };
+
+          Result.properties.value.propertyNames.forEach(propName => {
+            delete newValue[propName];
+          });
+          return newValue;
+        };
 
         let area = getArea(areaId);
 
@@ -959,7 +969,8 @@ export const Annotation = types
             id: areaId,
             object: data.to_name,
             ...data,
-            ...value,
+            // We need to omit value properties due to there may be conflicting property types, for example a text.
+            ...omitValueFields(value),
             value,
           };
 


### PR DESCRIPTION
* fix: DEV-2408: Regions disappearing from UI

* test: DEV-2408: Add test for wrong reordered results of per-region textarea and richtext

(cherry picked from commit 6ef0657ffa22fe4001129a84ef8aa21e430b2a0b)