### PR TITLE
fix: DEV-2203 Sidebar grid fix

### DIFF
--- a/src/components/App/App.styl
+++ b/src/components/App/App.styl
@@ -39,7 +39,7 @@
   height calc(100% - var(--topbar-height))
 
   &_view_all
-    grid-template-columns 100%
+    grid-template-columns 100% !important
 
   &_bsp
     display block

--- a/src/components/Timeline/Controls.styl
+++ b/src/components/Timeline/Controls.styl
@@ -34,7 +34,6 @@
     display flex
     max-width 310px
     justify-content space-between
-    width 390px
 
   .button
     background none


### PR DESCRIPTION
the fix was already set up but the override was not actually overriding in the css. the dreaded !important was used, which is not ideal however in this case this will only be necessary until the new sidebars are released as it is not an issue with them.  