### PR TITLE
fix: DEV-2364: Annotation history name/timestamp spacing improvement

### DIFF
--- a/src/common/Space/Space.styl
+++ b/src/common/Space/Space.styl
@@ -6,12 +6,14 @@
     &_horizontal
       grid-auto-flow column
       align-items center
-      grid-auto-columns max-content
 
     &_vertical
       grid-auto-flow row
       justify-content center
       grid-auto-rows max-content
+
+  &_direction_horizontal:not(&_truncated)
+    grid-auto-columns max-content
 
   &_spread
     width 100%
@@ -35,6 +37,9 @@
   &_size
     &_large
       grid-gap 32px
+
+    &_medium
+      grid-gap 16px
 
     &_small
       grid-gap 8px

--- a/src/common/Space/Space.tsx
+++ b/src/common/Space/Space.tsx
@@ -12,6 +12,7 @@ export interface SpaceProps {
   stretch?: boolean;
   align?: 'start' | 'end';
   collapsed?: boolean;
+  truncated?: boolean;
   className?: string;
 }
 
@@ -25,10 +26,11 @@ export const Space: FC<SpaceProps> = ({
   stretch,
   align,
   collapsed,
+  truncated,
   ...rest
 }) => {
   return (
-    <Block name="space" mod={{ direction, size, spread, stretch, align, collapsed }} mix={className} style={style} {...rest}>
+    <Block name="space" mod={{ direction, size, spread, stretch, align, collapsed, truncated }} mix={className} style={style} {...rest}>
       {children}
     </Block>
   );

--- a/src/components/CurrentEntity/AnnotationHistory.styl
+++ b/src/components/CurrentEntity/AnnotationHistory.styl
@@ -47,6 +47,11 @@
   &__date
     font-size 15px
 
+  &__name
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+
   &_disabled
     opacity 0.6
     border-radius 5px

--- a/src/components/CurrentEntity/AnnotationHistory.tsx
+++ b/src/components/CurrentEntity/AnnotationHistory.tsx
@@ -212,8 +212,8 @@ const HistoryItemComponent: FC<{
 
   return (
     <Block name="history-item" mod={{ inline, selected, disabled }} onClick={handleClick}>
-      <Space spread>
-        <Space size="small">
+      <Space spread size="medium" truncated>
+        <Space size="small" truncated>
           <Elem
             tag={Userpic}
             user={user}


### PR DESCRIPTION
Fixes the annotation history item spacing between the user name and timestamp, truncating user names which would cause the container to overflow.