### PR TITLE
fix: DEV-2465: Paragraphs data is not loading to QuickView

### DIFF
--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -60,7 +60,7 @@ export function getUrl(i: number, text: string) {
  * @param {boolean} [relative=true] - Whether relative urls are good or nood
  */
 export function isValidObjectURL(str: string, relative = false) {
-  if (!str) return false;
+  if (typeof str !== "string") return false;
   if (relative && str.startsWith("/")) return true;
   return /^https?:\/\//.test(str);
 }


### PR DESCRIPTION
we were getting an array instead of a string, which caused a js error that prevents the page from working correctly.
solution: I now check if `str` is actually a string before continuing