### PR TITLE
fix: DEV-2367: User is able to edit Time Series results imported as read-only

### DIFF
--- a/src/tags/object/TimeSeries/Channel.js
+++ b/src/tags/object/TimeSeries/Channel.js
@@ -282,6 +282,9 @@ class ChannelD3 extends React.Component {
         // all other space is taken by brushCreator
         group.selectAll(".overlay").style("pointer-events", "none");
 
+        if(r.readonly)
+          group.selectAll(".handle").remove();
+          
         if (r._brushRef === undefined || !r._brushRef.isConnected) {
           r._brushRef = group.select(".selection").node();
         }


### PR DESCRIPTION
resolving this issue by hiding the handles. would've preferred a more event driven solution, but i couldnt find a spot for that - it looks like we're leveraging d3 functionality