### PR TITLE
fix: DEV-2203: View all audio responsive

### DIFF
--- a/src/components/App/Grid.js
+++ b/src/components/App/Grid.js
@@ -119,16 +119,19 @@ export default class Grid extends Component {
 
   shift = delta => {
     const c = this.container.current;
-
+    
     if (!c) return;
-    const gap = 30;
-    const step = (c.offsetWidth + gap) / 2;
-    const current = (c.scrollLeft + delta) / step;
-    const next = delta > 0 ? Math.ceil(current) : Math.floor(current);
-    const count = this.props.annotations.length;
+    if (!c.viewing) c.viewing = 0;
 
-    if (next < 0 || next > count - 2) return;
-    c.scrollTo({ left: next * step, top: 0, behavior: "smooth" });
+    const count = this.props.annotations.length;
+    const next = c.viewing + delta; 
+    
+    if (next < 0 || next > count - 1) return;
+    const newPosition = c.children[next].offsetLeft;
+
+    c.viewing = next;
+
+    c.scrollTo({ left: newPosition, top: 0, behavior: "smooth" });
   };
 
   left = () => {

--- a/src/components/App/Grid.module.scss
+++ b/src/components/App/Grid.module.scss
@@ -1,4 +1,5 @@
 /* Grid (View All mode) */
+@import "../../assets/styles/global.scss";
 
 $gap: 30px;
 
@@ -6,6 +7,9 @@ $gap: 30px;
   flex-grow: 1;
   display: grid;
   grid-auto-columns: calc(50% - 15px);
+  @include respond("tablet") {
+    grid-auto-columns: 100%;
+  }
   grid-auto-flow: column;
   grid-column-gap: $gap;
   margin: 0 30px;

--- a/src/components/Timeline/Controls.tsx
+++ b/src/components/Timeline/Controls.tsx
@@ -83,8 +83,8 @@ export const Controls: FC<TimelineControlsProps> = memo(({
   }, [altControlsMode]);
 
   return (
-    <Block name="timeline-controls" tag={Space} spread>
-      <Elem name="group" tag={Space} size="small">
+    <Block name="timeline-controls" tag={Space} spread style={{ gridAutoColumns: 'auto' }}>
+      <Elem name="group" tag={Space} size="small" style={{ gridAutoColumns: 'auto' }}>
         {props.controls && Object.entries(props.controls).map(([name, enabled]) => {
           if (enabled === false) return;
 

--- a/src/components/Timeline/Timeline.styl
+++ b/src/components/Timeline/Timeline.styl
@@ -13,3 +13,6 @@
     grid-template-rows 1fr
     border-top 1px solid rgba(#000, 0.1)
     border-bottom 1px solid rgba(#000, 0.1)
+
+.audio
+  min-width 425px

--- a/src/components/Timeline/Views/Wave/Wave.tsx
+++ b/src/components/Timeline/Views/Wave/Wave.tsx
@@ -291,7 +291,7 @@ export const Wave: FC<TimelineViewProps> = ({
   return (
     <Block name="wave">
       <Elem name="controls">
-        <Space spread>
+        <Space spread style={{ gridAutoColumns: 'auto' }}>
           <Range
             continuous
             value={speed}


### PR DESCRIPTION
Refactored the shift logic to accommodate various configurations for the grid, and added a grid breakpoint for smaller screens, Some inline modifications to space elements to get controls to stay inside bounds until min width is hit.