### PR TITLE
fix: DEV-1975: DEV-1843: Support long unbroken taxonomy line breaks

### DIFF
--- a/src/components/Taxonomy/Taxonomy.module.scss
+++ b/src/components/Taxonomy/Taxonomy.module.scss
@@ -119,11 +119,18 @@
 }
 
 .taxonomy__item label {
+  overflow-wrap: break-word;
   flex: 1;
   flex-grow: 1;
   width: max-content;
   line-height: 2em;
   padding-right: 8px;
+}
+
+.taxonomy__item .width_check {
+  visibility: hidden;
+  position: absolute;
+  pointer-events: none;
 }
 
 .taxonomy__grouping {

--- a/src/components/Taxonomy/Taxonomy.tsx
+++ b/src/components/Taxonomy/Taxonomy.tsx
@@ -183,14 +183,17 @@ const Item: React.FC<RowProps> = ({ style, item, dimensionCallback, maxWidth }: 
   const isAddingItem = name === "" && onAddLabel;
 
   const itemContainer = useRef<any>();
-
+  const scrollSpace = maxWidth - itemContainer.current?.parentElement.offsetWidth || 0;
+  const labelMaxWidth = maxWidth - padding - scrollSpace - 90;
+  
   useEffect(() => {
     const container = itemContainer?.current;
-    
+
     if (container) {
       dimensionCallback(container.scrollWidth, container.scrollHeight );
     }
   }, []);
+  
 
   return (
     <div ref={itemContainer} style={{ paddingLeft: padding, maxWidth, ...style, width: 'fit-content' }}>
@@ -207,6 +210,13 @@ const Item: React.FC<RowProps> = ({ style, item, dimensionCallback, maxWidth }: 
             onChange={e => setSelected(path, e.currentTarget.checked)}
           />
           <label
+            style={{ left: `${padding + 44}px` }}
+            className={styles.width_check}
+          >
+            {name}
+          </label>
+          <label
+            style={{ maxWidth: `${labelMaxWidth}px` }}
             onClick={onClick}
             title={title}
             className={disabled ? styles.taxonomy__collapsable : undefined}

--- a/src/components/TreeStructure/TreeStructure.tsx
+++ b/src/components/TreeStructure/TreeStructure.tsx
@@ -57,7 +57,7 @@ const countChildNodes = (item: RowItem[]) => {
 };
 
 const blankItem = (path: string[], depth: number): RowItem => ({ label: "", depth, path, isOpen: true });
-const heightAccumulator: { [key: string]: number } = {};
+let heightAccumulator: { [key: string]: number } = {};
 let visibleCounter = 0;
 let visibleRendered = 0;
 let scrollTimeout: NodeJS.Timeout | null = null;
@@ -95,6 +95,11 @@ const TreeStructure = ({
     return heightAccumulator[`${index}`] || rowHeight;
   };
 
+  const rowHeightReCalcAll = () => {
+    heightAccumulator = {};
+    listRef.current.resetAfterIndex(0);
+  };
+
   const containerHeightCalc = () => {
     listRef.current.resetAfterIndex(0);
 
@@ -120,6 +125,7 @@ const TreeStructure = ({
     setOpenNodes({ ...openNodes, ...toggleItem });
     setData(recursiveTreeWalker({ items, toggleItem }));
     setContainerHeight(maxHeightPercentage * 0.01 * browserHeight);
+    rowHeightReCalcAll();
   };
 
   const addInside = (id?: string) => {

--- a/src/tags/control/Taxonomy.js
+++ b/src/tags/control/Taxonomy.js
@@ -224,7 +224,7 @@ const TaxonomyModel = types.compose("TaxonomyModel",
 
 const HtxTaxonomy = observer(({ item }) => {
   const style = { marginTop: "1em", marginBottom: "1em" };
-  const visibleStyle = item.perRegionVisible() ? {} : { display: "none" };
+  const visibleStyle = item.perRegionVisible() || item.isVisible ? {} : { display: "none" };
   const options = {
     showFullPath: item.showfullpath,
     leafsOnly: item.leafsonly,


### PR DESCRIPTION
In order to support text without spaces that exceed the maximum width for taxonomy, creation of an invisible taxonomy item to check its width and calculate how many lines was necessary per item. Additionally I added the missing visibility mixin check. 