### PR TITLE
feat: DEV-2431: Alt click deletes polygon points

### DIFF
--- a/src/regions/PolygonPoint.js
+++ b/src/regions/PolygonPoint.js
@@ -5,6 +5,7 @@ import { getParent, getRoot, hasParent, types } from "mobx-state-tree";
 
 import { guidGenerator } from "../core/Helpers";
 import { useRegionStyles } from "../hooks/useRegionColor";
+import { FF_DEV_2431, isFF } from "../utils/feature-flags";
 
 const PolygonPoint = types
   .model("PolygonPoint", {
@@ -264,6 +265,7 @@ const PolygonPointView = observer(({ item, name }) => {
           item.parent.deletePoint(item);
         }}
         onClick={ev => {
+          if (isFF(FF_DEV_2431) && ev.evt.altKey) return item.parent.deletePoint(item);
           if (item.parent.isDrawing && item.parent.points.length === 1) return;
           // don't unselect polygon on point click
           ev.evt.preventDefault();

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -68,6 +68,8 @@ export const FF_DEV_2458 = "ff_front_dev_2458_comments_for_skip_250522_short";
 
 export const FF_DEV_2480 = "ff_dev_2480_convenient_offsets_270522_short";
 
+export const FF_DEV_2431 = "ff_front_dev_2431_delete_polygon_points_080622_short";
+
 function getFeatureFlags() {
   return window.APP_SETTINGS?.feature_flags || {
     // ff_front_DEV_1713_audio_ui_150222_short: true,


### PR DESCRIPTION
Delete points with an alt/opt click, behind `ff_front_dev_2431_delete_polygon_points_080622_short`
