### PR TITLE
fix: DEV-2592: Bounding box is flickering during region creation

### DIFF
--- a/src/mixins/DrawingTool.js
+++ b/src/mixins/DrawingTool.js
@@ -416,12 +416,12 @@ const ThreePointsDrawingTool = DrawingTool.named("ThreePointsDrawingTool")
     };
 
     return {
-      updateDraw: throttle(function(x, y) {
+      updateDraw: (x, y) => {
         if (currentMode === DEFAULT_MODE)
           self.getCurrentArea()?.draw(x, y, points);
         else if (currentMode === DRAG_MODE)
           self.draw(x, y);
-      }, 48), // 3 frames, optimized enough and not laggy yet
+      },
 
       nextPoint(x, y) {
         points.push({ x, y });


### PR DESCRIPTION
this corrects an issue where the region flickers while dragging out a rectangle when using 3 point bbox feature