### PR TITLE
fix: DEV-2647: rotating bounding box bugs

### DIFF
--- a/src/regions/RectRegion.js
+++ b/src/regions/RectRegion.js
@@ -159,7 +159,6 @@ const Model = types
           self.rotation = self.rotationAtCreation;
         }
 
-        console.log("rectRegion draw", isAboveTheLine, isSecondLeftOfFirst, self.rotationAtCreation, self.rotation);
         self.height = Math.abs(h);
       }
       self.setPosition(self.x, self.y, self.width, self.height, self.rotation);

--- a/src/tags/control/Rectangle.js
+++ b/src/tags/control/Rectangle.js
@@ -6,6 +6,7 @@ import { customTypes } from "../../core/CustomTypes";
 import { AnnotationMixin } from "../../mixins/AnnotationMixin";
 import SeparatedControlMixin from "../../mixins/SeparatedControlMixin";
 import { ToolManagerMixin } from "../../mixins/ToolManagerMixin";
+import { FF_DEV_2132, isFF } from "../../utils/feature-flags";
 
 /**
  * Use the Rectangle tag to add a rectangle (Bounding Box) to an image without selecting a label. This can be useful when you have only one label to assign to a rectangle.
@@ -44,12 +45,18 @@ const TagAttrs = types.model({
   canrotate: types.optional(types.boolean, true),
 });
 
+const allowedToolNames = ['Rect'];
+
+if(isFF(FF_DEV_2132)) {
+  allowedToolNames.push('Rect3Point');
+}
+
 const Model = types
   .model({
     type: "rectangle",
   })
   .volatile(() => ({
-    toolNames: ['Rect'],
+    toolNames: allowedToolNames,
   }));
 
 const RectangleModel = types.compose("RectangleModel",

--- a/src/tools/Rect.js
+++ b/src/tools/Rect.js
@@ -5,7 +5,6 @@ import ToolMixin from "../mixins/Tool";
 import { ThreePointsDrawingTool, TwoPointsDrawingTool } from "../mixins/DrawingTool";
 import { AnnotationMixin } from "../mixins/AnnotationMixin";
 import { NodeViews } from "../components/Node/Node";
-import { FF_DEV_2132, isFF } from "../utils/feature-flags";
 
 const _Tool = types
   .model("RectangleTool", {
@@ -80,9 +79,83 @@ const _Tool = types
       return s.width > self.MIN_SIZE.X  && s.height * self.MIN_SIZE.Y;
     },
   }));
+  
+const _Tool3Point = types
+  .model("Rectangle3PointTool", {
+    group: "segmentation",
+    smart: true,
+    shortcut: "shift+R",
+  })
+  .views(self => {
+    const Super = {
+      createRegionOptions: self.createRegionOptions,
+      isIncorrectControl: self.isIncorrectControl,
+      isIncorrectLabel: self.isIncorrectLabel,
+    };
 
-const RectDrawingTool = isFF(FF_DEV_2132) ? ThreePointsDrawingTool : TwoPointsDrawingTool;
+    return {
 
-const Rect = types.compose(_Tool.name, ToolMixin, BaseTool, RectDrawingTool, _Tool, AnnotationMixin);
+      get getActivePolygon() {
+        const poly = self.currentArea;
 
-export { Rect };
+        if (poly && poly.closed) return null;
+        if (poly === undefined) return null;
+        if (poly && poly.type !== "rectangleregion") return null;
+
+        return poly;
+      },
+
+      get tagTypes() {
+        return {
+          stateTypes: "rectanglelabels",
+          controlTagTypes: ["rectanglelabels", "rectangle"],
+        };
+      },
+      get viewTooltip() {
+        return "3 Point Rectangle";
+      },
+      get iconComponent() {
+        return self.dynamic
+          ? NodeViews.RectRegionModel.altIcon
+          : NodeViews.RectRegionModel.icon;
+      },
+      get defaultDimensions() {
+        return DEFAULT_DIMENSIONS.rect;
+      },
+      createRegionOptions({ x, y }) {
+        return Super.createRegionOptions({
+          x,
+          y,
+          height: 1,
+          width: 1,
+        });
+      },
+
+      isIncorrectControl() {
+        return Super.isIncorrectControl() && self.current() === null;
+      },
+      isIncorrectLabel() {
+        return !self.current() && Super.isIncorrectLabel();
+      },
+      canStart() {
+        return self.current() === null;
+      },
+
+      current() {
+        return self.getActivePolygon;
+      },
+    };
+  })
+  .actions(self => ({
+    beforeCommitDrawing() {
+      const s = self.getActiveShape;
+
+      return s.width > self.MIN_SIZE.X  && s.height * self.MIN_SIZE.Y;
+    },
+  }));
+
+const Rect = types.compose(_Tool.name, ToolMixin, BaseTool, TwoPointsDrawingTool, _Tool, AnnotationMixin);
+
+const Rect3Point = types.compose(_Tool3Point.name, ToolMixin, BaseTool, ThreePointsDrawingTool, _Tool3Point, AnnotationMixin);
+
+export { Rect, Rect3Point };

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -5,7 +5,7 @@ import { Brush } from "./Brush";
 import { Erase } from "./Erase";
 import { KeyPoint } from "./KeyPoint";
 import { Polygon } from "./Polygon";
-import { Rect } from "./Rect";
+import { Rect, Rect3Point } from "./Rect";
 import { Ellipse } from "./Ellipse";
 import { Zoom } from "./Zoom";
 import { Rotate } from "./Rotate";
@@ -14,4 +14,4 @@ import { Contrast } from "./Contrast";
 import { FloodFill } from "./FloodFill";
 import { Selection } from "./Selection";
 
-export { Brush, Erase, KeyPoint, Polygon, Rect, Ellipse, Brightness, Contrast, Rotate, Zoom, FloodFill, Selection };
+export { Brush, Erase, KeyPoint, Polygon, Rect, Rect3Point, Ellipse, Brightness, Contrast, Rotate, Zoom, FloodFill, Selection };


### PR DESCRIPTION
this'll resolve an issue where unselecting a rectangle will deselect the rectangle tool altogether, giving the impression that the tool is no longer responsive.

2 point rectangle and 3 point rectangle can now both be used if the FF is set to true