### PR TITLE
fix: DEV-2696: 3point bbox tool remains selected but hidden, when user changes label configuration from Rectangle to RectangleLabels

### DIFF
--- a/src/mixins/DrawingTool.js
+++ b/src/mixins/DrawingTool.js
@@ -417,6 +417,9 @@ const ThreePointsDrawingTool = DrawingTool.named("ThreePointsDrawingTool")
     };
 
     return {
+      canStartDrawing() {
+        return !self.isIncorrectControl();
+      },
       updateDraw: (x, y) => {
         if (currentMode === DEFAULT_MODE)
           self.getCurrentArea()?.draw(x, y, points);
@@ -471,11 +474,13 @@ const ThreePointsDrawingTool = DrawingTool.named("ThreePointsDrawingTool")
         }
       },
       mousedownEv(ev, [x, y]) {
+        if (!self.canStartDrawing()) return;
         lastEvent = MOUSE_DOWN_EVENT;
         startPoint = { x, y };
         self.mode = "drawing";
       },
       mouseupEv(ev, [x, y]) {
+        if (!self.canStartDrawing()) return;
         if(self.isDrawing) {
           if (currentMode === DRAG_MODE) {
             self.draw(x, y);
@@ -485,6 +490,7 @@ const ThreePointsDrawingTool = DrawingTool.named("ThreePointsDrawingTool")
         }
       },
       clickEv(ev, [x, y]) {
+        if (!self.canStartDrawing()) return;
         if (currentMode === DEFAULT_MODE) {
           self._clickEv(ev, [x, y]);
         }


### PR DESCRIPTION
resolving an issue where 3 point rectangles were drawing before selecting a different tool even after removing them as an option from labeling settings