### PR TITLE
fix: DEV-3049: visual bug with the Zoom To flyout menu on smaller screen sizes

### DIFF
--- a/src/components/Toolbar/FlyoutMenu.styl
+++ b/src/components/Toolbar/FlyoutMenu.styl
@@ -60,6 +60,8 @@
     border-radius 5px
     background-color #fff
     box-shadow 0px 0px 0px 1px rgba(0, 0, 0, 0.05), 0px 5px 10px rgba(0, 0, 0, 0.1)
+    @media (max-width: 1200px) //1200px being the min-width on LSP .content-wrapper
+      right 1200px
 
     &__tooltip
       font-size 14px


### PR DESCRIPTION
minor correction for a fly out menu item positioning incorrectly on smaller screens (smaller than 1200px wide)