### PR TITLE
Fix: label svg width can't calculate when body is a flex box

### DIFF
--- a/src/utils/canvas.js
+++ b/src/utils/canvas.js
@@ -194,11 +194,12 @@ const labelToSVG = (function() {
     svgText.innerHTML = text;
 
     svg.appendChild(svgText);
-    document.body.appendChild(svg);
+    const temp = document.createElement("div");
+    temp.appendChild(svg);
+    document.body.appendChild(temp);
 
-    const textLen = svgText.getBoundingClientRect().width;
-
-    svg.remove();
+    const textLen = svg.getBoundingClientRect().width;
+    temp.remove();
 
     return textLen;
   }


### PR DESCRIPTION
when calculate a label svg width, we append a svg element to body dom, but if body has a 'display: flex;' style attribute, this way will not work.