### PR TITLE
feat: Add customizations to timeseries

### DIFF
--- a/src/tags/object/TimeSeries.js
+++ b/src/tags/object/TimeSeries.js
@@ -28,8 +28,6 @@ import PersistentStateMixin from "../../mixins/PersistentState";
 import "./TimeSeries/Channel";
 import { AnnotationMixin } from "../../mixins/AnnotationMixin";
 
-const moment = require("moment");
-
 /**
  * TimeSeries tag can be used to label time series data. Read more about Time Series Labeling on [the time series template page](../templates/time_series.html).
  *
@@ -66,6 +64,7 @@ const moment = require("moment");
  * @param {string} [timeColumn] Column name or index that provides temporal values. If your time series data has no temporal column then one is automatically generated.
  * @param {string} [timeFormat] Pattern used to parse values inside timeColumn, parsing is provided by d3, and follows `strftime` implementation
  * @param {string} [timeDisplayFormat] Format used to display temporal value. Can be a number or a date. If a temporal column is a date, use strftime to format it. If it's a number, use [d3 number](https://github.com/d3/d3-format#locale_format) formatting.
+ * @param {string} [durationDisplayFormat] Format used to display temporal duration value for brush range. If the temporal column is a date, use strftime to format it. If it's a number, use [d3 number](https://github.com/d3/d3-format#locale_format) formatting.
  * @param {string} [sep=,] Separator for your CSV file.
  * @param {string} [overviewChannels] Comma-separated list of channel names or indexes displayed in overview.
  * @param {string} [overviewWidth=25%] Default width of overview window in percents
@@ -80,6 +79,7 @@ const TagAttrs = types.model({
   sep: ",",
   timeformat: "",
   timedisplayformat: "",
+  durationdisplayformat: ".0f",
   overviewchannels: "", // comma-separated list of channels to show
   overviewwidth: "25%",
 
@@ -310,14 +310,14 @@ const Model = types
 
     formatDuration(duration) {
       if (!self._formatDuration) {
-        const { timedisplayformat: format, isDate } = self;
+        const { durationdisplayformat: format, isDate } = self;
 
-        if (format === "date") self._formatDuration = duration => moment.utc(duration).format("HH:mm:ss.SSS");
-        else if (format) self._formatDuration = isDate ? d3.timeFormat(format) : d3.format(format);
+        if (format) self._formatDuration = isDate ? d3.utcFormat(format) : d3.format(format);
         else self._formatDuration = String;
       }
       return self._formatDuration(duration);
     },
+
   }))
 
   .actions(self => ({

--- a/src/tags/object/TimeSeries.js
+++ b/src/tags/object/TimeSeries.js
@@ -28,6 +28,8 @@ import PersistentStateMixin from "../../mixins/PersistentState";
 import "./TimeSeries/Channel";
 import { AnnotationMixin } from "../../mixins/AnnotationMixin";
 
+const moment = require("moment");
+
 /**
  * TimeSeries tag can be used to label time series data. Read more about Time Series Labeling on [the time series template page](../templates/time_series.html).
  *
@@ -304,6 +306,17 @@ const Model = types
         else self._format = String;
       }
       return self._format(time);
+    },
+
+    formatDuration(duration) {
+      if (!self._formatDuration) {
+        const { timedisplayformat: format, isDate } = self;
+
+        if (format === "date") self._formatDuration = duration => moment.utc(duration).format("HH:mm:ss.SSS");
+        else if (format) self._formatDuration = isDate ? d3.timeFormat(format) : d3.format(format);
+        else self._formatDuration = String;
+      }
+      return self._formatDuration(duration);
     },
   }))
 

--- a/src/tags/object/TimeSeries/Channel.js
+++ b/src/tags/object/TimeSeries/Channel.js
@@ -515,9 +515,19 @@ class ChannelD3 extends React.Component {
     const markerId = `marker_${item.id}`;
     const clipPathId = `clip_${item.id}`;
 
-    const times = data[time];
-    const values = data[column];
-    const { series } = this.props;
+    let { series } = this.props;
+
+    series = series.filter(x => {
+      return x[column] !== null;
+    });
+
+    const times = series.map(x => {
+      return x[time];
+    });
+    
+    const values = series.map(x => {
+      return x[column];
+    });
 
     if (!values) {
       const names = Object.keys(data).filter(name => name !== time);

--- a/src/tags/object/TimeSeries/Channel.js
+++ b/src/tags/object/TimeSeries/Channel.js
@@ -378,7 +378,7 @@ class ChannelD3 extends React.Component {
 
     this.trackerX = dataX;
     this.tracker.attr("transform", `translate(${this.x(dataX) + 0.5},0)`);
-    this.trackerTime.text(this.formatTime(dataX) + (brushWidth === 0 ? "" : " [" + this.formatDuration(brushWidth) + "]"));
+    this.trackerTime.text(`${this.formatTime(dataX)}${brushWidth === 0 ? "" :  ` [${this.formatDuration(brushWidth)}]`}`);
     this.trackerValue.text(this.formatValue(dataY) + " " + this.props.item.units);
     this.trackerPoint.attr("cy", this.y(dataY));
     this.tracker.attr("text-anchor", screenX > width - 100 ? "end" : "start");
@@ -418,12 +418,13 @@ class ChannelD3 extends React.Component {
 
   renderXAxis = () => {
     const { item } = this.props;
+
+    if (!item.showaxis) return;
+
     const { width } = this.state;
     const { margin } = item.parent;
     const tickSize = this.height + margin.top;
     const shift = -margin.top;
-
-    if (!item.showaxis) return;
 
     let g = this.main.select(".xaxis");
 

--- a/src/tags/object/TimeSeries/Channel.js
+++ b/src/tags/object/TimeSeries/Channel.js
@@ -8,6 +8,7 @@ import Registry from "../../../core/Registry";
 import Types from "../../../core/Types";
 import { cloneNode, guidGenerator } from "../../../core/Helpers";
 import { checkD3EventLoop, fixMobxObserve, getOptimalWidth, getRegionColor, sparseValues } from "./helpers";
+import { markerSymbol } from "./symbols";
 import { errorBuilder } from "../../../core/DataValidator/ConfigValidator";
 import { TagParentMixin } from "../../../mixins/TagParentMixin";
 
@@ -29,6 +30,9 @@ import { TagParentMixin } from "../../../mixins/TagParentMixin";
  * @param {number} [height] height of the plot
  * @param {string=} [strokeColor=#f48a42] plot stroke color, expects hex value
  * @param {number=} [strokeWidth=1] plot stroke width
+ * @param {string=} [markerColor=#f48a42] plot stroke color, expects hex value
+ * @param {number=} [markerSize=0] plot stroke width
+ * @param {number=} [markerSymbol=circle] plot stroke width
  * @param {boolean} [fixedScale] if false current view scales to fit only displayed values; if given overwrites TimeSeries' fixedScale
  */
 
@@ -61,6 +65,10 @@ const TagAttrs = types.model({
 
   strokewidth: types.optional(types.string, "1"),
   strokecolor: types.optional(types.string, "#1f77b4"),
+
+  markersize: types.optional(types.string, "0"),
+  markercolor: types.optional(types.string, "#1f77b4"),
+  markersymbol: types.optional(types.string, "circle"),
 
   fixedscale: types.maybe(types.boolean),
 
@@ -504,6 +512,7 @@ class ChannelD3 extends React.Component {
     const height = this.height;
 
     this.zoomStep = slicesCount;
+    const markerId = `marker_${item.id}`;
     const clipPathId = `clip_${item.id}`;
 
     const times = data[time];
@@ -587,6 +596,17 @@ class ChannelD3 extends React.Component {
       .append("g")
       .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
+    const marker = main
+      .append("defs")
+      .append("marker")
+      .attr("id", markerId)
+      .attr("markerWidth", item.markersize)
+      .attr("markerHeight", item.markersize)
+      .attr("refX", item.markersize / 2)
+      .attr("refY", item.markersize / 2);
+
+    markerSymbol(marker, item.markersymbol, item.markersize, item.markercolor);
+
     main
       .append("clipPath")
       .attr("id", clipPathId)
@@ -623,7 +643,10 @@ class ChannelD3 extends React.Component {
       .attr("vector-effect", "non-scaling-stroke")
       .attr("fill", "none")
       .attr("stroke-width", item.strokewidth || 1)
-      .attr("stroke", item.strokecolor || "steelblue");
+      .attr("stroke", item.strokecolor || "steelblue")
+      .attr("marker-start", item.markersize > 0 ? `url(#${markerId})` : "")
+      .attr("marker-mid", item.markersize > 0 ? `url(#${markerId})` : "")
+      .attr("marker-end", item.markersize > 0 ? `url(#${markerId})` : "");
 
     this.renderTracker();
     this.updateTracker(0); // initial value, will be updated in setRangeWithScaling

--- a/src/tags/object/TimeSeries/Channel.js
+++ b/src/tags/object/TimeSeries/Channel.js
@@ -358,7 +358,7 @@ class ChannelD3 extends React.Component {
         const sticked = getRegion(d3.event.selection);
 
         brush.move(block, [x(sticked.start), x(sticked.end)]);
-        updateTracker(d3.mouse(this)[0]);
+        updateTracker(d3.mouse(this)[0], sticked.end - sticked.start);
       })
       .on("end", this.newBrushHandler)
       // replacing default filter to allow ctrl-click action
@@ -370,7 +370,7 @@ class ChannelD3 extends React.Component {
     this.gCreator.call(this.brushCreator);
   }
 
-  updateTracker = screenX => {
+  updateTracker = (screenX, brushWidth = 0) => {
     const { width } = this.state;
 
     if (screenX < 0 || screenX > width) return;
@@ -378,7 +378,7 @@ class ChannelD3 extends React.Component {
 
     this.trackerX = dataX;
     this.tracker.attr("transform", `translate(${this.x(dataX) + 0.5},0)`);
-    this.trackerTime.text(this.formatTime(dataX));
+    this.trackerTime.text(this.formatTime(dataX) + (brushWidth === 0 ? "" : " [" + this.formatDuration(brushWidth) + "]"));
     this.trackerValue.text(this.formatValue(dataY) + " " + this.props.item.units);
     this.trackerPoint.attr("cy", this.y(dataY));
     this.tracker.attr("text-anchor", screenX > width - 100 ? "end" : "start");
@@ -523,7 +523,7 @@ class ChannelD3 extends React.Component {
     if (!this.ref.current) return;
 
     const { data, item, range, time, column } = this.props;
-    const { isDate, formatTime, margin, slicesCount } = item.parent;
+    const { isDate, formatTime, formatDuration, margin, slicesCount } = item.parent;
     const height = this.height;
 
     this.zoomStep = slicesCount;
@@ -566,6 +566,7 @@ class ChannelD3 extends React.Component {
 
     this.formatValue = formatValue;
     this.formatTime = formatTime;
+    this.formatDuration = formatDuration;
 
     const offsetWidth = this.ref.current.offsetWidth;
     const width = offsetWidth ? offsetWidth - margin.left - margin.right : this.state.width;

--- a/src/tags/object/TimeSeries/symbols.js
+++ b/src/tags/object/TimeSeries/symbols.js
@@ -1,0 +1,44 @@
+import * as d3 from "d3";
+
+export const markerSymbol = (item, symbol, size, color) => {
+  switch(symbol) {
+    case "circle": {
+      item
+        .append("path")
+        .attr("d", d3.symbol().type(d3.symbolCircle).size(2 * size))
+        .attr("transform", `translate(${size / 2}, ${size / 2})`)
+        .attr("stroke", "none")
+        .attr("fill", color);
+      break;
+    }        
+    case "square": {
+      item
+        .append("path")
+        .attr("d", d3.symbol().type(d3.symbolSquare).size(2 * size))
+        .attr("transform", `translate(${size / 2}, ${size / 2})`)
+        .attr("stroke", "none")
+        .attr("fill", color);
+      break;
+    } 
+    case "triangle":       
+    case "triangleUp": {
+      item
+        .append("path")
+        .attr("d", d3.symbol().type(d3.symbolTriangle).size(2 * size))
+        .attr("transform", `translate(${size / 2}, ${size / 2})`)
+        .attr("stroke", "none")
+        .attr("fill", color);
+      break;
+    }        
+    case "triangleDown": {
+      item
+        .append("path")
+        .attr("d", d3.symbol().type(d3.symbolTriangle).size(2 * size))
+        .attr("transform", `translate(${size / 2}, ${size / 2}) rotate(180 0 0)`)
+        .attr("stroke", "none")
+        .attr("fill", color);
+      break;
+    }        
+  }
+
+};


### PR DESCRIPTION
Added optional markers to Start, End and Mid Points (circle, square, triangle-up and triangle-down)
Allowed functionality to disable the line (to switch between Scatter and Line+Scatter Plots)
Added the option for recognize NA / NULL in the value array (y-values) and remove that associated x-y-value from the data. This avoids an automatically inserted step that would "drag the line plot to zero, or add a marker" at that particular position.
Added the option to configure a custom range for both axis independent of the data ranges. This allows for fixed-scale axis for multiple tasks.
Added the option to hide the axis (incl. ticks and marks).
Added the width of the brush (selected portion of a plot), to the bottom right corner of the tracker (vertical cursor line).