### PR TITLE
fix: DEV-3322: Scale image via size, not scale

### DIFF
--- a/src/tags/object/Image.js
+++ b/src/tags/object/Image.js
@@ -464,8 +464,9 @@ const Model = types.model({
 
   get imageTransform() {
     const imgStyle = {
-      width: `${self.stageWidth}px`,
-      height: `${self.stageHeight}px`,
+      // scale transform leaves gaps on image border, so much better to change image sizes
+      width: `${self.stageWidth * self.zoomScale}px`,
+      height: `${self.stageHeight * self.zoomScale}px`,
       transformOrigin: "left top",
       transform: "none",
       filter: `brightness(${self.brightnessGrade}%) contrast(${self.contrastGrade}%)`,
@@ -476,7 +477,7 @@ const Model = types.model({
       const { zoomingPositionX = 0, zoomingPositionY = 0 } = self;
 
       imgTransform.push("translate3d(" + zoomingPositionX + "px," + zoomingPositionY + "px, 0)");
-      imgTransform.push("scale3d(" + self.zoomScale + ", " + self.zoomScale + ", 1)");
+      // imgTransform.push("scale3d(" + self.zoomScale + ", " + self.zoomScale + ", 1)");
     }
 
     if (self.rotation) {


### PR DESCRIPTION
`transform: scale` leaves gaps on image border, so visually regions may look shifted.
Much better to change image sizes directly via width/height props.