### PR TITLE
fix: DEV-3284: If video load times out display error message

### DIFF
--- a/src/components/VideoCanvas/VideoCanvas.tsx
+++ b/src/components/VideoCanvas/VideoCanvas.tsx
@@ -390,7 +390,6 @@ export const VideoCanvas = memo(forwardRef<VideoRef, VideoProps>((props, ref) =>
     if (videoDimensions.ratio !== ratio) {
       const result = { ...videoDimensions, ratio };
 
-      console.log(result);
       setVideoDimensions(result);
 
       if (props.zoom !== videoDimensions.ratio) {
@@ -405,7 +404,9 @@ export const VideoCanvas = memo(forwardRef<VideoRef, VideoProps>((props, ref) =>
 
     const checkVideoLoaded: (counter: number) => NodeJS.Timeout | undefined = (counter) => {
       if (isLoaded) return;
-      if (counter > 300) {
+      const loadingFailedWaitTime = 300;
+
+      if (counter > loadingFailedWaitTime) {
         const modalExists = document.querySelector('.ant-modal');
 
         if (!modalExists) InfoModal.error('There has been an error rendering your video, please check the format is supported');

--- a/src/components/VideoCanvas/VideoCanvas.tsx
+++ b/src/components/VideoCanvas/VideoCanvas.tsx
@@ -140,7 +140,7 @@ export const VideoCanvas = memo(forwardRef<VideoRef, VideoProps>((props, ref) =>
           offsetLeft, offsetTop, resultWidth, resultHeight,
         );
       }
-    } catch (e) {
+    } catch(e) {
       console.log('Error rendering video', e);
     }
   }, [videoDimensions, zoom, pan, filters, canvasWidth, canvasHeight]);

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,12 @@
+import { DependencyList, EffectCallback, useEffect, useRef } from "react";
+
+function useUpdateEffect(effect: EffectCallback, deps?: DependencyList) {
+  const isFirst = useRef(true);
+
+  useEffect(() => {
+    if (!isFirst.current) effect();
+    else isFirst.current = false;
+  }, deps);
+}
+
+export default useUpdateEffect;


### PR DESCRIPTION
Added a new hook and reduced renders a bit, there are still a lot of extra renders
Clear timeout on every call to check loaded (there are always at least two) 
If video is not loaded in 3 seconds about load display error message and reset spinner 