### PR TITLE
fix: DEV-3892: Get showSubmitButton=false to work

### DIFF
--- a/src/tags/control/TextArea/TextArea.js
+++ b/src/tags/control/TextArea/TextArea.js
@@ -65,7 +65,7 @@ const TagAttrs = types.model({
   label: types.optional(types.string, ''),
   value: types.maybeNull(types.string),
   rows: types.optional(types.string, '1'),
-  showsubmitbutton: types.optional(types.boolean, true),
+  showsubmitbutton: types.maybeNull(types.boolean),
   placeholder: types.maybeNull(types.string),
   maxsubmissions: types.maybeNull(types.string),
   editable: types.optional(types.boolean, false),
@@ -337,7 +337,7 @@ const HtxTextArea = observer(({ item }) => {
 
   const visibleStyle = item.perRegionVisible() ? {} : { display: 'none' };
 
-  const showAddButton = item.annotation.editable && rows !== 1 && item.showsubmitbutton;
+  const showAddButton = item.annotation.editable && (item.showsubmitbutton ?? rows !== 1);
   const itemStyle = {};
 
   if (showAddButton) itemStyle['marginBottom'] = 0;
@@ -573,7 +573,7 @@ const HtxTextAreaRegionView = observer(({ item, area, collapsed, setCollapsed, o
 
   if (item.annotation.readonly) props['disabled'] = true;
 
-  const showAddButton = item.annotation.editable && rows !== 1 && item.showsubmitbutton;
+  const showAddButton = item.annotation.editable && (item.showsubmitbutton ?? rows !== 1);
   const itemStyle = {};
 
   if (showAddButton) itemStyle['marginBottom'] = 0;

--- a/src/tags/control/TextArea/TextArea.js
+++ b/src/tags/control/TextArea/TextArea.js
@@ -65,7 +65,7 @@ const TagAttrs = types.model({
   label: types.optional(types.string, ''),
   value: types.maybeNull(types.string),
   rows: types.optional(types.string, '1'),
-  showsubmitbutton: types.optional(types.boolean, false),
+  showsubmitbutton: types.optional(types.boolean, true),
   placeholder: types.maybeNull(types.string),
   maxsubmissions: types.maybeNull(types.string),
   editable: types.optional(types.boolean, false),
@@ -337,7 +337,7 @@ const HtxTextArea = observer(({ item }) => {
 
   const visibleStyle = item.perRegionVisible() ? {} : { display: 'none' };
 
-  const showAddButton = (item.annotation.editable && rows !== 1) || item.showSubmitButton;
+  const showAddButton = item.annotation.editable && rows !== 1 && item.showsubmitbutton;
   const itemStyle = {};
 
   if (showAddButton) itemStyle['marginBottom'] = 0;
@@ -573,7 +573,7 @@ const HtxTextAreaRegionView = observer(({ item, area, collapsed, setCollapsed, o
 
   if (item.annotation.readonly) props['disabled'] = true;
 
-  const showAddButton = (item.annotation.editable && rows !== 1) || item.showSubmitButton;
+  const showAddButton = item.annotation.editable && rows !== 1 && item.showsubmitbutton;
   const itemStyle = {};
 
   if (showAddButton) itemStyle['marginBottom'] = 0;


### PR DESCRIPTION
Disable TextArea Add button with showSubmitButton=false.

Now this parameter is true by default because previously it had no effect and true should not do anything actually, but false forces button to disappear.