### PR TITLE
fix: DEV-3901: Paragraph overflow text issue when outliner disabled (revert)

### DIFF
--- a/src/components/App/App.styl
+++ b/src/components/App/App.styl
@@ -60,7 +60,6 @@
 
   &__annotation
     padding 1em
-    overflow auto
 
   &__infobar
     padding 6px 1em 7px


### PR DESCRIPTION
This reverts commit 8b45238a98180f3358876043425772f53510cc52.