### PR TITLE
fix: DEV-3427: View slider follows the playhead

### DIFF
--- a/src/components/Timeline/Views/Frames/Frames.tsx
+++ b/src/components/Timeline/Views/Frames/Frames.tsx
@@ -248,8 +248,13 @@ export const Frames: FC<TimelineViewProps> = ({
   }, [offset, step]);
 
   useEffect(() => {
-    if (playing && position > lastVisibleFrame) {
-      setScroll({ left: lastVisibleFrame * step });
+    const leftOfView = position < firstVisibleFrame;
+    const rightOfView = position > lastVisibleFrame;
+
+    if (playing && (leftOfView || rightOfView)) {
+      const left = leftOfView ? lastVisibleFrame / step : lastVisibleFrame * step;
+      
+      setScroll({ left });
     }
   }, [playing, position]);
 


### PR DESCRIPTION
if playhead is ahead of indicator and view, pull view back to playhead