### PR TITLE
fix: DEV-3990: Cleanup worker and audio contexts

### DIFF
--- a/src/lib/AudioUltra/Common/Worker/index.ts
+++ b/src/lib/AudioUltra/Common/Worker/index.ts
@@ -46,6 +46,7 @@ export class ComputeWorker {
       };
 
       self.addEventListener('message', (e) => {
+        if (e.data) return;
         const { data, type, eventId } = e.data;
 
         switch(type) {
@@ -93,7 +94,7 @@ export class ComputeWorker {
     return response?.data?.result;
   }
 
-  terminate() {
+  destroy() {
     this.worker.terminate();
   }
 

--- a/src/lib/AudioUltra/Controls/Player.ts
+++ b/src/lib/AudioUltra/Controls/Player.ts
@@ -4,7 +4,7 @@ import { clamp } from '../Common/Utils';
 import { Waveform } from '../Waveform';
 
 export class Player extends Destructable {
-  private audio!: WaveformAudio;
+  private audio?: WaveformAudio;
   private wf: Waveform;
   private timer!: number;
   private loop:  {start: number, end: number}|null = null;
@@ -159,8 +159,9 @@ export class Player extends Destructable {
   }
 
   destroy() {
-    super.destroy();
     this.stop();
+    this.cleanupSource();
+    super.destroy();
   }
 
   private updatePlayback() {
@@ -244,6 +245,15 @@ export class Player extends Destructable {
     this.audio.source?.stop(0);
     this.audio.disconnect();
   }
+
+  private cleanupSource() {
+    if (this.isDestroyed || !this.audio) return;
+    this.disconnectSource();
+
+    delete this.audio.source;
+    delete this.audio;
+  }
+
 
   private watch = () => {
     if (!this.playing) return;

--- a/src/lib/AudioUltra/Media/ChannelData.ts
+++ b/src/lib/AudioUltra/Media/ChannelData.ts
@@ -1,3 +1,4 @@
+import { Destructable } from '../Common/Destructable';
 import { ComputeWorker } from '../Common/Worker';
 import { Visualizer } from '../Visual/Visualizer';
 import { Waveform } from '../Waveform';
@@ -15,7 +16,7 @@ type ChunkComputerOutput = Float32Array[][];
 const worker = new Worker(new URL('./ChannelDataWorker.ts', import.meta.url));
 const chunkComputer = new ComputeWorker(worker);
 
-export class ChannelData {
+export class ChannelData extends Destructable {
   private options: ChannelDataOptions;
 
   // Audio data
@@ -45,8 +46,17 @@ export class ChannelData {
   }
 
   constructor(options: ChannelDataOptions) {
+    super();
     this.options = options;
     this.data = options.data;
+  }
+
+  destroy() {
+    chunkComputer.destroy();
+    this.data = new Float32Array();
+    this.normalized = [];
+    this.views = [];
+    super.destroy();
   }
 
   async recalculate(){

--- a/src/lib/AudioUltra/Media/MediaLoader.ts
+++ b/src/lib/AudioUltra/Media/MediaLoader.ts
@@ -8,7 +8,7 @@ export type Options = {
 
 export class MediaLoader extends Destructable {
   private wf: Waveform;
-  private audio?: WaveformAudio;
+  private audio?: WaveformAudio | null;
   private loaded = false;
   private options: Options;
   private cancel: () => void;
@@ -36,7 +36,7 @@ export class MediaLoader extends Destructable {
   async decodeAudioData(arrayBuffer: ArrayBuffer) {
     if (!this.audio?.context || this.isDestroyed) return null;
 
-    return await this.audio.context.decodeAudioData(arrayBuffer).then((buffer) => {
+    return await this.audio.decodeAudioData(arrayBuffer).then((buffer) => {
       if (this.isDestroyed) return null;
       return buffer;
     });
@@ -61,7 +61,6 @@ export class MediaLoader extends Destructable {
       };
 
       try {
-
         if (!audio.context) {
           return Promise.resolve(null);
         }
@@ -104,17 +103,8 @@ export class MediaLoader extends Destructable {
     this.reset();
 
     if (this.audio) {
-      this.audio.disconnect();
-
-      if (this.audio.context) {
-        this.audio.context.close().then(() => {
-          console.log('destroyed context');
-        });
-      }
-
-      delete this.audio.context;
-      delete this.audio.buffer;
-      delete this.audio;
+      this.audio.destroy();
+      this.audio = null;
     }
   }
 

--- a/src/lib/AudioUltra/Media/MediaLoader.ts
+++ b/src/lib/AudioUltra/Media/MediaLoader.ts
@@ -17,8 +17,6 @@ export class MediaLoader extends Destructable {
   sampleRate = 0;
   loadingProgressType: 'determinate' | 'indeterminate';
 
-  static promiseChain: Promise<any> |null = null;
-
   constructor(wf: Waveform, options: Options) {
     super();
     this.wf = wf;
@@ -65,27 +63,12 @@ export class MediaLoader extends Destructable {
           return Promise.resolve(null);
         }
 
-        if (MediaLoader.promiseChain) {
-          MediaLoader.promiseChain = MediaLoader.promiseChain.then(() => {
-            return this.decodeAudioData(xhr.response);
-          }).then((buffer) => {
-            if (buffer) {
-              return playAudio(buffer);
-            }
-            return null;
-          });
-        } else {
-          MediaLoader.promiseChain = this.decodeAudioData(xhr.response).then((buffer) => {
-            if (buffer) {
-              return playAudio(buffer);
-            }
-            return null;
-          }).finally(() => {
-            MediaLoader.promiseChain = null;
-          });
-        }
-
-        return MediaLoader.promiseChain;
+        return this.decodeAudioData(xhr.response).then((buffer) => {
+          if (buffer) {
+            return playAudio(buffer);
+          }
+          return null;
+        });
       } catch (err) {
       // TODO: Handle properly (exiquio)
       // NOTE: error is being received

--- a/src/lib/AudioUltra/Media/WaveformAudio.ts
+++ b/src/lib/AudioUltra/Media/WaveformAudio.ts
@@ -5,11 +5,11 @@ export interface WaveformAudioOptions {
 }
 
 export class WaveformAudio {
-  context: AudioContext;
-  analyzer: AnalyserNode | null = null;
-  source: AudioBufferSourceNode | null = null;
-  gain: GainNode | null = null;
-  buffer: AudioBuffer | null = null;
+  context?: AudioContext;
+  analyzer?: AnalyserNode;
+  source?: AudioBufferSourceNode;
+  gain?: GainNode;
+  buffer?: AudioBuffer;
 
   private _rate = 1;
   private _volume = 1;
@@ -30,7 +30,7 @@ export class WaveformAudio {
   }
 
   get sampleRate() {
-    return this.context.sampleRate;
+    return this.context?.sampleRate;
   }
 
   get volume() {
@@ -61,16 +61,23 @@ export class WaveformAudio {
 
   connect() {
     if (this.source) this.disconnect();
+    if (!this.context || !this.buffer) return;
 
-    const source = this.context.createBufferSource();
+    const source = this.context?.createBufferSource();
+
+    if (!source) return;
 
     source.buffer = this.buffer;
 
-    const analyzer = this.context.createAnalyser();
+    const analyzer = this.context?.createAnalyser();
+
+    if (!analyzer) return;
 
     analyzer.fftSize = 2048;
 
-    const gain = this.context.createGain();
+    const gain = this.context?.createGain();
+
+    if (!gain) return;
 
     source.connect(gain);
 
@@ -88,15 +95,22 @@ export class WaveformAudio {
   }
 
   disconnect() {
-    if (!this.source) return;
-
-    this.analyzer?.disconnect();
-    this.source.disconnect();
-    this.gain?.disconnect();
-
-    this.source = null;
-    this.analyzer = null;
-    this.gain = null;
+    if (this.source) {
+      this.source.disconnect();
+      delete this.source;
+    }
+    if (this.analyzer) {
+      this.analyzer.disconnect();
+      delete this.analyzer;
+    }
+    if (this.gain) {
+      this.gain.disconnect();
+      delete this.gain;
+    }
+  }
+  
+  destroy() {
+    this.disconnect();
   }
 
   mute() {

--- a/src/lib/AudioUltra/Media/WaveformAudio.ts
+++ b/src/lib/AudioUltra/Media/WaveformAudio.ts
@@ -97,17 +97,17 @@ export class WaveformAudio {
   }
 
   disconnect() {
-    if (this.source) {
-      this.source.disconnect();
-      delete this.source;
+    if (this.gain) {
+      this.gain.disconnect();
+      delete this.gain;
     }
     if (this.analyzer) {
       this.analyzer.disconnect();
       delete this.analyzer;
     }
-    if (this.gain) {
-      this.gain.disconnect();
-      delete this.gain;
+    if (this.source) {
+      this.source.disconnect();
+      delete this.source;
     }
   }
   

--- a/src/lib/AudioUltra/Regions/Regions.ts
+++ b/src/lib/AudioUltra/Regions/Regions.ts
@@ -144,7 +144,7 @@ export class Regions {
     const region = this.findRegion(regionId);
 
     if (this.deleteable && region?.deleteable) {
-      region.destroy();
+      region.destroy(false);
       this.regions = this.regions.filter(r => r !== region);
     }
 

--- a/src/lib/AudioUltra/Regions/Segment.ts
+++ b/src/lib/AudioUltra/Regions/Segment.ts
@@ -400,14 +400,14 @@ export class Segment extends Events<SegmentEvents> {
    * Remove all event listeners and remove the region from the canvas
    * Remove region's layer
    */
-  destroy() {
+  destroy(notify = true) {
     if (!this.deleteable || this.isDestroyed) return;
 
+    if (notify) {
+      this.remove();
+    }
+
     super.destroy();
-
-    this.controller.layerGroup.removeLayer(this.layer);
-
-    this.remove();
   }
 
   toJSON() {

--- a/src/lib/AudioUltra/Waveform.ts
+++ b/src/lib/AudioUltra/Waveform.ts
@@ -234,17 +234,20 @@ export class Waveform extends Events<WaveformEventTypes> {
   }
 
   async load() {
+    if (this.isDestroyed) return;
+
     const audio = await this.media.load({
       muted: this.params.muted ?? false,
       volume: this.params.volume ?? 1,
       rate: this.params.rate ?? 1,
     });
 
+    if (this.isDestroyed) return;
+
     if (audio) {
       this.player.init(audio);
       this.visualizer.init(audio);
       this.loaded = true;
-
       this.invoke('load');
     }
   }
@@ -326,12 +329,16 @@ export class Waveform extends Events<WaveformEventTypes> {
    * Detach all the event handlers, cleanup the cache, remove Waveform from the dom
    */
   destroy() {
-    super.destroy(); // Events -> Destructable
+    if (this.isDestroyed) return;
+
     this.regions.destroy();
-    this.visualizer.destroy();
     this.media.destroy();
+    this.player.destroy();
+    this.visualizer.destroy();
     this.cursor.destroy();
     this.tooltip.destroy();
+
+    super.destroy(); // Events -> Destructable
   }
 
   addRegion(options: RegionOptions, render = true) {


### PR DESCRIPTION
This PR improves destructor behaviour amongst Audio classes. This is to enable a more stable usage of the async nature of the audio loading, processing.

There is an overall issue with working with the WebAudio api that can produce issues of crashing the browser, and no clear way to resolve it.
So in the meantime it is guarded all over and attempted to cleanup with as forceful efforts that can be done, and it is promise chained against the MediaLoader instance to try and stop the race condition and browser crashes that come with `decodeAudioData` getting run multiple times. This improves the usability, but crashes are still possible just much more unlikely.

As it is right now, we are already closing and removing contexts so there is not much more that can be done at this time. The crashes are extremely seldom, and with this fix it becomes almost never. I was able to switch between tasks at varying speeds in succession and not see a crash for > 20 minutes. The issue actually only presents itself in the conflict of calling decodeAudioData at the same time as another context, but there is no way other than waiting for a previous one to complete, to guarantee its closed. So this PR is to achieve that, further investigations will have to be done as to alternatives to this Web API.