### PR TITLE
fix: DEV-3919: Outliner on a narrow screen

### DIFF
--- a/src/components/App/App.styl
+++ b/src/components/App/App.styl
@@ -41,12 +41,9 @@
   max-width 100%
   height calc(100% - var(--topbar-height))
 
+  // view all and new UI have only one children, so no grid required
   &_view_all
-    grid-template-columns 100% !important
-
   &_outliner
-    grid-template-columns 100%
-
   &_bsp
     display block
 


### PR DESCRIPTION
Preview is good because it uses bottomSidePanel settings, but small screens use previous grid layout.