### PR TITLE
fix: LSDV-1023: Handle both media and xhr load errors for audio

### DIFF
--- a/src/lib/AudioUltra/Media/MediaLoader.ts
+++ b/src/lib/AudioUltra/Media/MediaLoader.ts
@@ -92,9 +92,9 @@ export class MediaLoader extends Destructable {
         this.decoderResolve?.();
         return this.audio;
       }
-    } catch {
+    } catch (err: any) {
       // If the media element error event was triggered, we can't continue
-      this.wf.setError('An error occurred while loading the audio file. Please select another file or try again.');
+      this.wf.setError('An error occurred while loading the audio file. Please select another file or try again.', err);
       return null;
     }
 
@@ -121,8 +121,7 @@ export class MediaLoader extends Destructable {
 
         return this.audio ?? null;
       } catch (err) {
-        this.wf.setError('An error occurred while decoding the audio file. Please select another file or try again.');
-        console.error('An audio decoding error occurred', err);
+        this.wf.setError('An error occurred while decoding the audio file. Please select another file or try again.', err);
       }
     }
 

--- a/src/lib/AudioUltra/Media/WaveformAudio.ts
+++ b/src/lib/AudioUltra/Media/WaveformAudio.ts
@@ -180,7 +180,7 @@ export class WaveformAudio extends Events<WaveformAudioEvents> {
 
   mediaReady = (e: any) => {
     if (e.type === 'error') {
-      this.mediaReject?.(e);
+      this.mediaReject?.(this.el?.error);
     } else {
       this.mediaResolve?.();
     }

--- a/src/lib/AudioUltra/Waveform.ts
+++ b/src/lib/AudioUltra/Waveform.ts
@@ -144,6 +144,7 @@ export interface WaveformOptions {
 }
 interface WaveformEventTypes extends RegionsGlobalEvents, RegionGlobalEvents {
   'load': () => void;
+  'error': (error: Error) => void;
   'resize': (wf: Waveform, width: number, height: number) => void;
   'pause': () => void;
   'play': () => void;
@@ -334,8 +335,9 @@ export class Waveform extends Events<WaveformEventTypes> {
     this.visualizer.setDecodingProgress(chunk, total);
   }
 
-  setError(error: string) {
-    this.visualizer.setError(error);
+  setError(errorMessage: string, error?: Error) {
+    this.invoke('error', [error || new Error(errorMessage)]);
+    this.visualizer.setError(errorMessage);
   }
 
   /**

--- a/src/lib/AudioUltra/react/index.ts
+++ b/src/lib/AudioUltra/react/index.ts
@@ -7,6 +7,7 @@ export const useWaveform = (
   containter: MutableRefObject<HTMLElement | null | undefined>,
   options: Omit<WaveformOptions, 'container'> & {
     onLoad?: (wf: Waveform) => void,
+    onError?: (error: Error) => void,
     onSeek?: (time: number) => void,
     onPlaying?: (playing: boolean) => void,
     onRateChange?: (rate: number) => void,
@@ -44,6 +45,9 @@ export const useWaveform = (
     });
     wf.on('pause', () => {
       setPlaying(false);
+    });
+    wf.on('error', (error) => {
+      options?.onError?.(error);
     });
     wf.on('playing', (time: number) => {
       if (playing && !isTimeRelativelySimilar(time, currentTime, duration)) {


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
Whenever a network error occurred when either loading of the media element, or the arraybuffer data, it requires that we handle the error and show this state to the user.



#### What does this fix?
Bubbles up all audio loading errors as human friendly messages.



#### What is the new behavior?
All errors are handled for audio loading of media element source, xhr calls and decoding processes.



#### What is the current behavior?
Only xhr calls and decoding processes were handling errors.



#### What libraries were added/updated?
N/A



#### Does this change affect performance?
No



#### Does this change affect security?
No



#### What alternative approaches were there?
N/A



#### What feature flags were used to cover this change?

```
ff_front_dev_2715_audio_3_280722_short
```


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [X] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Audio v3 (codename AudioUltra)
