### PR TITLE
fix: LSDV-4541: Audio segment is being deleted by pressing delete button

### DIFF
--- a/e2e/tests/audio.test.js
+++ b/e2e/tests/audio.test.js
@@ -88,3 +88,29 @@ Scenario('Check if regions is selected', async function({ I, LabelStudio, AtAudi
   AtAudioView.clickAt(220);
   AtSidebar.dontSeeSelectedRegion();
 });
+
+Scenario('Delete region with delete hotkey', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+  LabelStudio.setFeatureFlags({
+    ff_front_dev_2715_audio_3_280722_short: true,
+  });
+  I.amOnPage('/');
+
+  LabelStudio.init(params);
+
+  await AtAudioView.waitForAudio();
+
+  I.waitForDetached('loading-progress-bar', 10);
+
+  await AtAudioView.lookForStage();
+
+  AtSidebar.seeRegions(1);
+
+  // creating a new region
+  AtAudioView.dragAudioRegion(160,80);
+
+  I.pressKey('Delete');
+
+  I.pressKey('1');
+
+  AtSidebar.seeRegions(1);
+});

--- a/e2e/tests/audio.test.js
+++ b/e2e/tests/audio.test.js
@@ -89,7 +89,7 @@ Scenario('Check if regions is selected', async function({ I, LabelStudio, AtAudi
   AtSidebar.dontSeeSelectedRegion();
 });
 
-Scenario('Delete region with delete hotkey', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+Scenario('Delete region by pressing delete hotkey', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
   LabelStudio.setFeatureFlags({
     ff_front_dev_2715_audio_3_280722_short: true,
   });

--- a/src/core/settings/keymap.json
+++ b/src/core/settings/keymap.json
@@ -102,10 +102,6 @@
     "key": "backspace",
     "description": "Delete selected region"
   },
-  "region:remove": {
-    "key": "delete",
-    "description": "Delete selected region"
-  },
   "region:cycle": {
     "key": "alt+.",
     "description": "Cycle through regions"
@@ -114,6 +110,10 @@
     "key": "ctrl+d",
     "mac": "command+d",
     "description": "Duplicate selected region"
+  },
+  "segment:delete": {
+    "key": "delete",
+    "description": "Delete selected region"
   },
   "media:playpause": {
     "key": "alt+space",

--- a/src/core/settings/keymap.json
+++ b/src/core/settings/keymap.json
@@ -102,6 +102,10 @@
     "key": "backspace",
     "description": "Delete selected region"
   },
+  "region:remove": {
+    "key": "delete",
+    "description": "Delete selected region"
+  },
   "region:cycle": {
     "key": "alt+.",
     "description": "Cycle through regions"

--- a/src/tags/object/AudioUltra/view.tsx
+++ b/src/tags/object/AudioUltra/view.tsx
@@ -125,6 +125,10 @@ const AudioUltraView: FC<AudioUltraProps> = ({ item }) => {
         waveform.current?.regions.clearSegments(false);
       });
 
+      hotkeys.addNamed('region:remove', () => {
+        waveform.current?.regions.clearSegments(false);
+      });
+
       hotkeys.addNamed('region:delete-all', () => {
         waveform.current?.regions.clearSegments();
       });

--- a/src/tags/object/AudioUltra/view.tsx
+++ b/src/tags/object/AudioUltra/view.tsx
@@ -125,7 +125,7 @@ const AudioUltraView: FC<AudioUltraProps> = ({ item }) => {
         waveform.current?.regions.clearSegments(false);
       });
 
-      hotkeys.addNamed('region:remove', () => {
+      hotkeys.addNamed('segment:delete', () => {
         waveform.current?.regions.clearSegments(false);
       });
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
If a gray segment is created accidentally, it's impossible to remove it by pressing the delete button. It's creating some confusing while user is annotating



#### What does this fix?
User can delete a gray segment by pressing the delete button


#### What is the current behavior?
User can delete a gray segment just by pressing backspace button



#### What libraries were added/updated?
None



#### Does this change affect performance?
no



#### Does this change affect security?
no



#### What feature flags were used to cover this change?
none



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [x] e2e
- [ ] integration
- [ ] unit
