### PR TITLE
fix: LSDV-3009: Fix draft saving stuck

### DIFF
--- a/src/stores/Annotation/Annotation.js
+++ b/src/stores/Annotation/Annotation.js
@@ -11,7 +11,16 @@ import Types from '../../core/Types';
 import Area from '../../regions/Area';
 import Result from '../../regions/Result';
 import Utils from '../../utils';
-import { FF_DEV_1284, FF_DEV_1598, FF_DEV_2100, FF_DEV_2100_A, FF_DEV_2432, FF_DEV_3391, isFF } from '../../utils/feature-flags';
+import {
+  FF_DEV_1284,
+  FF_DEV_1598,
+  FF_DEV_2100,
+  FF_DEV_2100_A,
+  FF_DEV_2432,
+  FF_DEV_3391,
+  FF_LSDV_3009,
+  isFF
+} from '../../utils/feature-flags';
 import { delay, isDefined } from '../../utils/utilities';
 import { CommentStore } from '../Comment/CommentStore';
 import RegionStore from '../RegionStore';
@@ -647,7 +656,7 @@ export const Annotation = types
       const result = self.serializeAnnotation({ fast: true });
       // if this is new annotation and no regions added yet
 
-      if (!self.pk && !result.length) return;
+      if (!isFF(FF_LSDV_3009) && !self.pk && !result.length) return;
 
       self.setDraftSelected();
       self.versions.draft = result;

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -159,6 +159,14 @@ export const FF_DEV_4075 = 'fflag_fix_front_dev_4075_taxonomy_overlap_281222_sho
   */
 export const FF_LSDV_1148 = 'fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short';
 
+/**
+ * Removing interrupting from the draft saving
+ *
+ * Without this flag we have a situation when changes in history leading to the empty results break functionality of adding comments and make the draft saving process indicator stay forever.
+ * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short
+ */
+export const FF_LSDV_3009 = 'fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short';
+
 function getFeatureFlags() {
   return {
     ...(window.APP_SETTINGS?.feature_flags ?? {}),


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The problem with saving a draft with empty results affects the functionality of comments.



#### What does this fix?
This allows saving drafts with empty results. So that there should not be a problem with adding comments caused by this issue. And by this we also avoid draft saving permanent state. 



#### What is the new behavior?
We can save a draft with empty results. But this solve the issue.



#### What is the current behavior?
Currently saving a draft with empty results gets and this causes adding comments functionality to hang.



#### What libraries were added/updated?
N/A



#### Does this change affect performance?
Nope


#### Does this change affect security?
Nope



#### What alternative approaches were there?
We also can rollback saving a draft if we can't save it. But this will create an ugly artifact in the UI and adding comments will still save an empty draft.



#### What feature flags were used to cover this change?
`fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [x] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`Annotation History`, `Autosave`, `Draft`, `Comments`