### PR TITLE
fix: LSDV-4627: App crash with FF for DEV-3391 is on

### DIFF
--- a/e2e/tests/image.magic-wand.test.js
+++ b/e2e/tests/image.magic-wand.test.js
@@ -79,11 +79,11 @@ Scenario('Make sure the magic wand works in a variety of scenarios', async funct
     annotations: [annotationEmpty],
   };
 
-  I.amOnPage('/');
-
   LabelStudio.setFeatureFlags({
     'fflag_feat_front_dev_4081_magic_wand_tool': true,
   });
+
+  I.amOnPage('/');
 
   I.executeScript(initLabelStudio, params);
 

--- a/src/core/Registry.ts
+++ b/src/core/Registry.ts
@@ -1,5 +1,3 @@
-import { FF_DEV_4081, isFF } from '../utils/feature-flags';
-
 /**
  * Class for register View
  */
@@ -77,10 +75,6 @@ class _Registry {
   getTool(name: string) {
     const model = this.tools[name];
 
-    if (name === 'magicwand' && !isFF(FF_DEV_4081)) {
-      throw new Error('The magicwand feature flag is not on');
-    }
-
     if (!model) {
       const models = Object.keys(this.tools);
 
@@ -97,10 +91,6 @@ class _Registry {
    */
   getModelByTag(tag: string) {
     const model = this.models[tag];
-
-    if (tag === 'magicwand' && !isFF(FF_DEV_4081)) {
-      throw new Error('magicwand feature flag (fflag_fix_front_dev_3391_interactive_view_all) is not on');
-    }
 
     if (!model) {
       const models = Object.keys(this.models);

--- a/src/tags/control/MagicWand.js
+++ b/src/tags/control/MagicWand.js
@@ -96,7 +96,6 @@ import { ToolManagerMixin } from '../../mixins/ToolManagerMixin';
  */
 
 const TagAttrs = types.model({
-  name: types.identifier,
   toname: types.maybeNull(types.string),
   opacity: types.optional(customTypes.range(), '0.6'),
   blurradius: types.optional(types.string, '5'),

--- a/src/tags/control/MagicWand.js
+++ b/src/tags/control/MagicWand.js
@@ -6,6 +6,7 @@ import { customTypes } from '../../core/CustomTypes';
 import { AnnotationMixin } from '../../mixins/AnnotationMixin';
 import SeparatedControlMixin from '../../mixins/SeparatedControlMixin';
 import { ToolManagerMixin } from '../../mixins/ToolManagerMixin';
+import { FF_DEV_4081, isFF } from '../../utils/feature-flags';
 
 /**
  * The `Magicwand` tag makes it possible to click in a region of an image a user is doing segmentation
@@ -131,6 +132,6 @@ const HtxView = () => {
   return null;
 };
 
-Registry.addTag('magicwand', MagicWandModel, HtxView);
+isFF(FF_DEV_4081) && Registry.addTag('magicwand', MagicWandModel, HtxView);
 
 export { HtxView, MagicWandModel };


### PR DESCRIPTION
MagicWand model is incompatible with new version of ControlBase tag and crashes the app. So we can just remove `name` param as it's defined in base tag.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)

- [ ] Product design
- [x] Frontend



### Describe the reason for change
Application crashes on load with FF for DEV-3391 on.
The reason is the `name` param defined in `MagicWand` model
and it's clashed with `name` definition in `ControlBase`.

#### What does this fix?
Removes `MagicWand#name` param because it's already defined





### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

It fixes breaking change.


### What level of testing was included in the change?
_(check all that apply)_
- [x] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
View All, Magic Wand, mst models