### PR TITLE
feat: LSDV-4701: Audio v3 webaudio alternative decoder option

### DIFF
--- a/e2e/tests/audio/audio-webaudio-decoder.test.js
+++ b/e2e/tests/audio/audio-webaudio-decoder.test.js
@@ -1,0 +1,255 @@
+Feature('Audio WebAudio Decoder');
+
+const config = `
+<View>
+  <Header value="Select regions:"></Header>
+  <Labels name="label" toName="audio" choice="multiple">
+    <Label value="Beat" background="yellow"></Label>
+    <Label value="Voice" background="red"></Label>
+    <Label value="Guitar" background="blue"></Label>
+    <Label value="Other"></Label>
+  </Labels>
+  <Header value="Select genre:"></Header>
+  <Choices name="choice" toName="audio" choice="multiple">
+    <Choice value="Lo-Fi" />
+    <Choice value="Rock" />
+    <Choice value="Pop" />
+  </Choices>
+  <Header value="Listen the audio:"></Header>
+  <AudioPlus name="audio" value="$url"></AudioPlus>
+</View>
+`;
+
+const configSpeech = `
+<View>
+    <AudioPlus name="audio" value="$url" decoder="webaudio"></AudioPlus>
+    <Labels name="label" toName="audio">
+      <Label value="Speech"/>
+      <Label value="Noise" background="grey"/>
+    </Labels>
+    <TextArea name="transcription" toName="audio"
+              perRegion="true" whenTagName="label" whenLabelValue="Speech"
+              displayMode="region-list"/>
+    <Choices name="sentiment" toName="audio" showInline="true"
+             perRegion="true" whenTagName="label" whenLabelValue="Speech">
+        <Choice value="Positive"/>
+        <Choice value="Neutral"/>
+        <Choice value="Negative"/>
+    </Choices>                               
+  </View>
+`;
+
+const data = {
+  url: 'https://htx-misc.s3.amazonaws.com/opensource/label-studio/examples/audio/barradeen-emotional.mp3',
+};
+
+const annotations = [
+  {
+    from_name: 'choice',
+    id: 'hIj6zg57SY',
+    to_name: 'audio',
+    type: 'choices',
+    origin: 'manual',
+    value: {
+      choices: ['Lo-Fi'],
+    },
+  },
+  {
+    from_name: 'label',
+    id: 'JhxupEJWlW',
+    to_name: 'audio',
+    original_length: 98.719925,
+    type: 'labels',
+    origin: 'manual',
+    value: {
+      channel: 1,
+      end: 59.39854733358493,
+      labels: ['Other'],
+      start: 55.747572792986325,
+    },
+  },
+];
+
+const params = { annotations: [{ id: 'test', result: annotations }], config, data };
+const paramsSpeech = { annotations: [{ id: 'test', result: [] }], config: configSpeech, data };
+
+Scenario('Check if regions are selected', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+  LabelStudio.setFeatureFlags({
+    ff_front_dev_2715_audio_3_280722_short: true,
+  });
+  I.amOnPage('/');
+
+  LabelStudio.init(params);
+
+  await AtAudioView.waitForAudio();
+
+  I.waitForDetached('loading-progress-bar', 10);
+
+  await AtAudioView.lookForStage();
+
+  AtSidebar.seeRegions(1);
+
+  // creating a new region
+  I.pressKey('1');
+  AtAudioView.dragAudioRegion(160,80);
+  I.pressKey('u');
+
+  AtSidebar.seeRegions(2);
+
+  AtAudioView.clickAt(170);
+  AtSidebar.seeSelectedRegion();
+  AtAudioView.clickAt(170);
+  AtSidebar.dontSeeSelectedRegion();
+  AtAudioView.dragAudioRegion(170,40);
+  AtSidebar.seeSelectedRegion();
+  AtAudioView.clickAt(220);
+  AtSidebar.dontSeeSelectedRegion();
+});
+
+Scenario('Check if multiple regions are working changing labels', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+  LabelStudio.setFeatureFlags({
+    ff_front_dev_2715_audio_3_280722_short: true,
+  });
+  I.amOnPage('/');
+
+  LabelStudio.init(paramsSpeech);
+
+  await AtAudioView.waitForAudio();
+
+  I.waitForDetached('loading-progress-bar', 10);
+
+  await AtAudioView.lookForStage();
+
+  for (let i = 0; i < 20; i++) {
+    // creating a new region
+    I.pressKey('1');
+    AtAudioView.dragAudioRegion((40 * i) + 10,30);
+    AtAudioView.clickAt((40 * i) + 20);
+    I.pressKey('2');
+    I.pressKey('1');
+    I.pressKey('u');
+  }
+
+  AtSidebar.seeRegions(20);
+
+  for (let i = 0; i < 20; i++) {
+    // creating a new region
+    AtAudioView.clickAt((40 * i) + 20);
+    AtSidebar.seeSelectedRegion();
+    I.pressKey('u');
+  }
+
+  AtSidebar.seeRegions(20);
+
+  I.pressKey('u');
+
+  AtSidebar.dontSeeSelectedRegion();
+});
+
+Scenario('Can select a region below a hidden region', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+  LabelStudio.setFeatureFlags({
+    ff_front_dev_2715_audio_3_280722_short: true,
+  });
+  I.amOnPage('/');
+
+  LabelStudio.init(paramsSpeech);
+
+  await AtAudioView.waitForAudio();
+
+  I.waitForDetached('loading-progress-bar', 10);
+
+  await AtAudioView.lookForStage();
+
+  // create a new region
+  I.pressKey('1');
+  AtAudioView.dragAudioRegion(50, 80);
+  I.pressKey('u');
+
+  AtSidebar.seeRegions(1);
+
+  // create a new region above the first one
+  I.pressKey('2');
+  AtAudioView.dragAudioRegion(49, 81);
+  I.pressKey('u');
+
+  AtSidebar.seeRegions(2);
+
+  // click on the top-most region visible to select it
+  AtAudioView.clickAt(50);
+  AtSidebar.seeSelectedRegion('Noise');
+
+  // hide the region
+  AtSidebar.hideRegion('Noise');
+
+  // click on the region below the hidden one to select it
+  AtAudioView.clickAt(50);
+  AtSidebar.seeSelectedRegion('Speech');
+});
+
+Scenario('Delete region by pressing delete hotkey', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+  LabelStudio.setFeatureFlags({
+    ff_front_dev_2715_audio_3_280722_short: true,
+  });
+  I.amOnPage('/');
+
+  LabelStudio.init(params);
+
+  await AtAudioView.waitForAudio();
+
+  I.waitForDetached('loading-progress-bar', 10);
+
+  await AtAudioView.lookForStage();
+
+  AtSidebar.seeRegions(1);
+
+  // creating a new region
+  AtAudioView.dragAudioRegion(160,80);
+
+  I.pressKey('Delete');
+
+  I.pressKey('1');
+
+  AtSidebar.seeRegions(1);
+});
+
+Scenario('Check if there are ghost regions', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+  LabelStudio.setFeatureFlags({
+    ff_front_dev_2715_audio_3_280722_short: true,
+  });
+  I.amOnPage('/');
+
+  LabelStudio.init(paramsSpeech);
+
+  await AtAudioView.waitForAudio();
+
+  I.waitForDetached('loading-progress-bar', 10);
+
+  await AtAudioView.lookForStage();
+
+  // creating a new region
+  I.pressKey('1');
+  AtAudioView.dragAudioRegion(300,80);
+  I.pressKey('u');
+
+
+  // creating a ghost region
+  I.pressKey('1');
+  AtAudioView.dragAudioRegion(160,80, false);
+  I.pressKey('1');
+  I.wait(1);
+  I.pressMouseUp();
+  I.wait(1);
+
+  // checking if the created region is selected
+  AtAudioView.clickAt(310);
+  AtSidebar.seeSelectedRegion();
+
+  // trying to select the ghost region, if there is no ghost region, the region will keep selected
+  // as ghost region is not selectable and impossible to change the label, the created region will be deselected if there is a ghost region created.
+  AtAudioView.clickAt(170);
+  I.pressKey('2');
+  AtSidebar.seeSelectedRegion();
+
+  AtSidebar.seeRegions(2);
+});
+

--- a/src/lib/AudioUltra/Media/AudioDecoderPool.ts
+++ b/src/lib/AudioUltra/Media/AudioDecoderPool.ts
@@ -1,14 +1,16 @@
 import { info } from '../Common/Utils';
+import { BaseAudioDecoder } from './BaseAudioDecoder';
+import { WebAudioDecoder } from './WebAudioDecoder';
 import { AudioDecoder } from './AudioDecoder';
 
-export type DecoderCache = Map<string, AudioDecoder>;
+export type DecoderCache = Map<string, BaseAudioDecoder>;
 export type DecoderProxy = ReturnType<typeof decoderProxy>;
 
 const REMOVAL_GRACE_PERIOD = 5000; // 5s grace period for removal of the decoder from the cache
 
-function decoderProxy(cache: DecoderCache, src: string, splitChannels: boolean) {
-  const key = `${src}:${splitChannels}`;
-  const decoder = cache.get(key) ?? new AudioDecoder(key);
+function decoderProxy(cache: DecoderCache, src: string, splitChannels: boolean, decoderType: 'webaudio' | 'ffmpeg' = 'ffmpeg') {
+  const key = `${src}:${splitChannels}:${decoderType}`;
+  const decoder = cache.get(key) ?? (decoderType === 'ffmpeg' ? new AudioDecoder(src) : new WebAudioDecoder(src));
 
   decoder.renew();
   cache.set(key, decoder);
@@ -17,11 +19,11 @@ function decoderProxy(cache: DecoderCache, src: string, splitChannels: boolean) 
     get(target, prop) {
       if (prop in target) {
         // Operate on the instance, and cache it
-        const instance = cache.get(key) as AudioDecoder;
+        const instance = cache.get(key) as BaseAudioDecoder;
 
         // Cancel the removal of the decoder from the cache
         // It is still in use
-        if (instance.removalId) {
+        if (instance?.removalId) {
           clearTimeout(instance.removalId);
           info('decode:renew', key);
           instance.removalId = null;
@@ -29,7 +31,7 @@ function decoderProxy(cache: DecoderCache, src: string, splitChannels: boolean) 
           cache.set(key, instance);
         }
 
-        const val = instance[prop as keyof AudioDecoder];
+        const val = instance[prop as keyof BaseAudioDecoder];
 
         // When the instance is no longer in use, remove it from the cache
         // Allow for a grace period before removal so that the decoded results can be reused
@@ -54,8 +56,8 @@ function decoderProxy(cache: DecoderCache, src: string, splitChannels: boolean) 
 export class AudioDecoderPool {
   static cache: DecoderCache = new Map();
 
-  getDecoder(src: string, splitChannels: boolean): DecoderProxy {
-    const decoder = decoderProxy(AudioDecoderPool.cache, src, splitChannels);
+  getDecoder(src: string, splitChannels: boolean, decoderType: 'webaudio' | 'ffmpeg' = 'ffmpeg'): DecoderProxy {
+    const decoder = decoderProxy(AudioDecoderPool.cache, src, splitChannels, decoderType);
 
     return decoder;
   }

--- a/src/lib/AudioUltra/Media/BaseAudioDecoder.ts
+++ b/src/lib/AudioUltra/Media/BaseAudioDecoder.ts
@@ -1,0 +1,115 @@
+
+import { Events } from '../Common/Events';
+import { info } from '../Common/Utils';
+ 
+interface AudioDecoderEvents {
+  progress: (chunk: number, total: number) => void;
+}
+
+export const DEFAULT_FREQUENCY_HZ = 44100;
+
+export abstract class BaseAudioDecoder extends Events<AudioDecoderEvents> {
+  chunks?: Float32Array[][];
+  protected cancelled = false;
+  protected decodeId = 0; // if id=0, decode is not in progress
+  protected _dataLength = 0;
+  protected _dataSize = 0;
+  protected _channelCount = 1;
+  protected _sampleRate = DEFAULT_FREQUENCY_HZ;
+  protected _duration = 0;
+
+  protected decodingResolve?: () => void;
+  decodingPromise: Promise<void> | undefined;
+
+  /**
+   * Timeout for removal of the decoder from the cache.
+   * Any subsequent requests for the same source will renew the decoder and cancel the removal.
+   */
+  removalId: any = null;
+
+  constructor(protected src: string) {
+    super();
+  }
+
+  get channelCount() {
+    return this._channelCount;
+  }
+
+  get sampleRate() {
+    return this._sampleRate;
+  }
+
+  get duration() {
+    return this._duration;
+  }
+
+  get dataLength() {
+    if (this.chunks && !this._dataLength) {
+      this._dataLength = (this.chunks?.reduce((a, b) => a + b.reduce((_a, _b) => _a + _b.length, 0), 0) ?? 0) / this._channelCount;
+    }
+    return this._dataLength;
+  }
+
+  get dataSize() {
+    if (this.chunks && !this._dataSize) {
+      this._dataSize = (this.chunks?.reduce((a, b) => a + b.reduce((_a, _b) => _a + _b.byteLength, 0), 0) ?? 0) / this._channelCount;
+    }
+    return this._dataSize;
+  }
+
+  get sourceDecoded() {
+    return this.chunks !== undefined;
+  }
+
+  get sourceDecodeCancelled() {
+    return this.cancelled && this.decodeId === 0;
+  }
+
+  /**
+   * Cancel the decoding process.
+   * This will stop the generator and dispose the worker.
+   */
+  cancel() {
+    if (!this.cancelled) {
+      info('decode:cancelled', this.src);
+    }
+    this.cancelled = true;
+    this.decodeId = 0;
+
+    this.dispose();
+  }
+
+  /**
+   * Dispose the decoder, worker, or any other resources.
+   */
+  protected abstract dispose(): void;
+
+  /**
+   * Renew the decoder instance to allow reuse of the same decoder with any resultant encoding data.
+   */
+  renew() {
+    this.cancelled = false;
+  }
+
+  /**
+   * Since this is a singleton, we don't want to destroy the instance but clear all active
+   * subscriptions and cancel any pending decoding work
+   */
+  destroy() {
+    super.removeAllListeners();
+    this.cancel();
+  }
+
+  /**
+   * Resolve and remove the shared decoding promise.
+   */
+  cleanupResolvers() {
+    this.decodingResolve?.();
+    this.decodingResolve = undefined;
+    this.decodingPromise = undefined;
+    info('decode:cleanup', this.src);
+  }
+
+  abstract init(arraybuffer: ArrayBuffer): Promise<void> 
+  abstract decode(options?: { multiChannel?: boolean }): Promise<void>;
+}

--- a/src/lib/AudioUltra/Media/MediaLoader.ts
+++ b/src/lib/AudioUltra/Media/MediaLoader.ts
@@ -77,6 +77,7 @@ export class MediaLoader extends Destructable {
       ...options,
       src: this.options.src,
       splitChannels: this.wf.params.splitChannels,
+      decoderType: this.wf.params.decoderType,
     });
 
     // If this failed to allocate an audio decoder, we can't continue

--- a/src/lib/AudioUltra/Media/WebAudioDecoder.ts
+++ b/src/lib/AudioUltra/Media/WebAudioDecoder.ts
@@ -1,0 +1,104 @@
+// eslint-disable-next-line
+// @ts-ignore
+import { info } from '../Common/Utils';
+import { BaseAudioDecoder } from './BaseAudioDecoder';
+
+
+export class WebAudioDecoder extends BaseAudioDecoder {
+  private arraybuffer?: ArrayBuffer;
+  private context?: OfflineAudioContext;
+
+  /**
+   * Initialize the decoder if it has not already been initialized.
+   */
+  async init(arraybuffer: ArrayBuffer) {
+    this.arraybuffer = arraybuffer;
+
+    info('decode:worker:ready', this.src);
+  }
+
+  /**
+   * Decode the audio file using the WebAudio API.
+   */
+  async decode(options?: { multiChannel?: boolean }): Promise<void> {
+    // If the worker has cached data we can skip the decode step
+    if (this.sourceDecoded) {
+      info('decode:cached', this.src);
+      return;
+    }
+    if (this.sourceDecodeCancelled) {
+      throw new Error('WebAudioDecoder decode cancelled and contains no data, did you call decoder.renew()?');
+    }
+    // The decoding process is already in progress, so wait for it to finish
+    if (this.decodingPromise) {
+      info('decode:inprogress', this.src);
+      return this.decodingPromise;
+    }
+    if (!this.arraybuffer) throw new Error('WebAudioDecoder not initialized, did you call decoder.init()?');
+
+    info('decode:start', this.src);
+
+    // Generate a unique id for this decode operation
+    this.decodeId = Date.now();
+    // This is a shared promise which will be observed by all instances of the same source
+    this.decodingPromise = new Promise(resolve => (this.decodingResolve = resolve as any));
+
+    try {
+      const buffer = await new Promise((resolve, reject) => {
+        if (!this.context) {
+          this.context = this.createOfflineAudioContext();
+        }
+        if (!this.context || !this.arraybuffer) return reject(new Error('WebAudioDecoder not initialized, did you call decoder.init()?'));
+        // Safari doesn't support promise based decodeAudioData by default
+        if ('webkitAudioContext' in window) {
+          this.context?.decodeAudioData(
+            this.arraybuffer,
+            data => resolve(data),
+            err => reject(err),
+          );
+        } else {
+          this.context?.decodeAudioData(this.arraybuffer).then(
+            resolve,
+          ).catch(
+            reject,
+          );
+        }
+      }) as AudioBuffer;
+
+      this._channelCount = options?.multiChannel ? buffer.numberOfChannels : 1;
+      this._sampleRate = buffer.sampleRate;
+      this._duration = buffer.duration;
+
+      const chunks = Array.from({ length: this._channelCount }).map(() => Array.from({ length: 1 }) as Float32Array[]);
+
+      chunks.forEach((_, index) => {
+        chunks[index] = [buffer.getChannelData(index)];
+      });
+
+      this.chunks = chunks;
+
+      info('decode:complete', this.src);
+    } finally {
+      this.dispose();
+    }
+  }
+
+  /**
+   * Dispose and free up resources.
+   */
+  protected dispose() {
+    delete this.arraybuffer;
+    delete this.context;
+
+    this.cleanupResolvers();
+  }
+
+  private createOfflineAudioContext(sampleRate?: number) {
+    if (!(window as any).WebAudioOfflineAudioContext) {
+      (window as any).WebAudioOfflineAudioContext = new (window.OfflineAudioContext ||
+                (window as any).webkitOfflineAudioContext)(1, 2, sampleRate ?? this.sampleRate);
+    }
+    return (window as any).WebAudioOfflineAudioContext;
+  }
+}
+

--- a/src/lib/AudioUltra/Waveform.ts
+++ b/src/lib/AudioUltra/Waveform.ts
@@ -73,6 +73,11 @@ export interface WaveformOptions {
   splitChannels?: boolean;
 
   /**
+   * Decoder used to decode the audio to waveform data.
+   */
+  decoderType?: 'webaudio' | 'ffmpeg';
+
+  /**
    * Center the view to the cursor when zoomin
    * @default false
    */

--- a/src/tags/object/AudioUltra/model.js
+++ b/src/tags/object/AudioUltra/model.js
@@ -49,6 +49,7 @@ import { WS_SPEED, WS_VOLUME, WS_ZOOM_X } from './constants';
  * @param {boolean} [autocenter=true] – Always place cursor in the middle of the view
  * @param {boolean} [scrollparent=true] – Wave scroll smoothly follows the cursor
  * @param {boolean} [splitchannels=true] – Display stereo channels separately
+ * @param {string} [decoder=ffmpeg] – Decoder type to use to decode audio data. ("ffmpeg" or "webaudio")
  */
 const TagAttrs = types.model({
   name: types.identifier,
@@ -71,6 +72,7 @@ const TagAttrs = types.model({
   autocenter: types.optional(types.boolean, true),
   scrollparent: types.optional(types.boolean, true),
   splitchannels: types.optional(types.boolean, isFF(FF_LSDV_3028)), // FF_LSDV_3028: true by default when on
+  decoder: types.optional(types.enumeration(['ffmpeg', 'webaudio']), 'ffmpeg'),
 });
 
 export const AudioModel = types.compose(

--- a/src/tags/object/AudioUltra/model.js
+++ b/src/tags/object/AudioUltra/model.js
@@ -8,7 +8,7 @@ import ProcessAttrsMixin from '../../../mixins/ProcessAttrs';
 import { SyncMixin } from '../../../mixins/SyncMixin';
 import { AudioRegionModel } from '../../../regions/AudioRegion';
 import Utils from '../../../utils';
-import { FF_DEV_2461, FF_LSDV_3028, isFF } from '../../../utils/feature-flags';
+import { FF_DEV_2461, FF_LSDV_3028, FF_LSDV_4701, isFF } from '../../../utils/feature-flags';
 import { isDefined } from '../../../utils/utilities';
 import { isTimeSimilar } from '../../../lib/AudioUltra';
 import ObjectBase from '../Base';
@@ -72,7 +72,7 @@ const TagAttrs = types.model({
   autocenter: types.optional(types.boolean, true),
   scrollparent: types.optional(types.boolean, true),
   splitchannels: types.optional(types.boolean, isFF(FF_LSDV_3028)), // FF_LSDV_3028: true by default when on
-  decoder: types.optional(types.enumeration(['ffmpeg', 'webaudio']), 'ffmpeg'),
+  decoder: types.optional(types.enumeration(['ffmpeg', 'webaudio']), isFF(FF_LSDV_4701) ? 'ffmpeg' : 'webaudio'), // FF_LSDV_4701: 'ffmpeg' by default when on, 'webaudio' otherwise
 });
 
 export const AudioModel = types.compose(

--- a/src/tags/object/AudioUltra/view.tsx
+++ b/src/tags/object/AudioUltra/view.tsx
@@ -33,6 +33,7 @@ const AudioUltraView: FC<AudioUltraProps> = ({ item }) => {
       height: item.height && !isNaN(Number(item.height)) ? Number(item.height) : 96,
       waveHeight: item.waveheight && !isNaN(Number(item.waveheight)) ? Number(item.waveheight) : 32,
       splitChannels: item.splitchannels,
+      decoderType: item.decoder,
       volume: item.defaultvolume ? Number(item.defaultvolume) : 1,
       amp: item.defaultscale ? Number(item.defaultscale) : 1,
       zoom: item.defaultzoom ? Number(item.defaultzoom) : 1,

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -195,6 +195,7 @@ function getFeatureFlags() {
     ...(window.APP_SETTINGS?.feature_flags ?? {}),
     [FF_DEV_1564_DEV_1565]: true,
     [FF_DEV_1566]: true,
+    [FF_LSDV_4701]: true,
   };
 }
 

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -184,6 +184,12 @@ export const FF_LSDV_3028 = 'fflag_feat_front_lsdv_3028_audio_v3_multichannel_de
  */
 export const FF_LSDV_3009 = 'fflag_fix_font_lsdv_3009_draft_saving_stuck_130223_short';
 
+/**
+ * Enables the ffmpeg audio decoder to be the default.
+ * @link https://app.launchdarkly.com/default/production/features/fflag_feat_front_lsdv_4701_audio_default_decoder_ffmpeg_long
+ */
+export const FF_LSDV_4701 = 'fflag_feat_front_lsdv_4701_audio_default_decoder_ffmpeg_long';
+
 function getFeatureFlags() {
   return {
     ...(window.APP_SETTINGS?.feature_flags ?? {}),


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
To support more options for audio data decoding, which allows different support levels for formats (webaudio api follows strictly browser formats, where ffmpeg wasm is based on the included compiled codecs). This helps to give more flexibility to meet the needs of the labelling projects, for example. Video Timeline segmentation of webm files. That would require switching the audio tag to this `webaudio` decoder option to meet that need as the included ffmpeg wasm decoder currently does not support that format. But for larger duration audio, it is more stable to use the `ffmpeg` decoder. This way we can quickly support more use cases, without having to compromise the UI/UX, or reverting/pointing users to Audio v1 which would be lacking many core features that we support in v3.


#### What is the new behavior?

Introduces a new tag attribute `decoder`

This attribute is an enum of `ffmpeg` or `webaudio` and defaults to the current decoder `ffmpeg`.

```xml
<Audio decoder="ffmpeg|webaudio" ... />
```
When using `webaudio` decoder it has some performance tradeoffs which are tied to browser limitations. Uses more memory on average, and therefore will support shorter durations with a format support that mirrors your browser level support for media files.

When using `ffmpeg` decoder it allows for greater level performance and is not tied to browser limitations. Uses less memory, and therefore will support larger durations with a format support based on the decoders included codecs (specific supported formats are being tested and updated in documentation within another ticket).

Either decoder will support the same feature set of Audio v3, and should be a transparent change for the user.

#### What is the current behavior?

Currently there is only the ffmpeg decoder option.


#### What libraries were added/updated?
N/A


#### Does this change affect performance?
N/A



#### Does this change affect security?
N/A



#### What alternative approaches were there?
N/A


#### What feature flags were used to cover this change?

`fflag_feat_front_lsdv_4701_audio_default_decoder_ffmpeg_long` was added as a way to control default behaviour of the Audio config. The default will be `ffmpeg` unless otherwise specified.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [X] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Audio v3
