### PR TITLE
fix: LSDV-4662: Use empty range GET requests instead of HEAD to avoid CORS issue on video presigned urls

### DIFF
--- a/src/components/VideoCanvas/VirtualVideo.tsx
+++ b/src/components/VideoCanvas/VirtualVideo.tsx
@@ -12,7 +12,10 @@ const canPlayUrl = async (url: string) => {
   const video = document.createElement('video');
 
   const fileMeta = await fetch(url, {
-    method: 'HEAD',
+    method: 'GET',
+    headers: {
+      'Range': 'bytes=0-0',
+    },
   });
 
   const fileType = fileMeta.headers.get('content-type');


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
An issue occurs when a user is using presigned urls to load Video. This is a result of presigned urls being specific to a particular method, which is `GET` in this case. Previously we were using `HEAD` requests to check content type header to ensure playback was possible, so that we could early report issues back to the user. This ends up producing a false positive since the `HEAD` requests will fail on any presigned urls, but would otherwise allow the video to load because the url was still valid, but only valid to `GET`.



#### What does this fix?
Uses an empty `Range: bytes=0-0` header `GET` request to the file, mimicking a `HEAD` request in that we will not request data but receive the metadata we would otherwise require. This will then succeed and not trigger invalid file format errors etc.

#### What libraries were added/updated?
N/A



#### Does this change affect performance?
N/A


#### Does this change affect security?
N/A



#### What alternative approaches were there?
N/A



#### What feature flags were used to cover this change?
N/A



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Video
