### PR TITLE
fix: LSDV-4593: CORS error requesting audio

### DIFF
--- a/src/lib/AudioUltra/Media/MediaLoader.ts
+++ b/src/lib/AudioUltra/Media/MediaLoader.ts
@@ -185,12 +185,13 @@ export class MediaLoader extends Destructable {
         }
       });
 
-      const newUrl = new URL(url, url.startsWith('/') ? window.location.href : undefined);
+      // Handle relative urls, by converting them to absolute so any query params can be preserved
+      const newUrl = new URL(url, /^https?/.exec(url) ? undefined : window.location.href);
 
       // Arbitrary setting of query param to stop caching from reusing any media requests which may have less headers
       // cached than this request. This is to prevent a CORS error when the headers are different between partial
       // content and full content requests.
-      newUrl.searchParams.set('t', '1');
+      newUrl.searchParams.set('lsref', '1');
 
       xhr.open('GET', newUrl.toString(), true);
       xhr.send();

--- a/src/lib/AudioUltra/Media/MediaLoader.ts
+++ b/src/lib/AudioUltra/Media/MediaLoader.ts
@@ -185,7 +185,14 @@ export class MediaLoader extends Destructable {
         }
       });
 
-      xhr.open('GET', url, true);
+      const newUrl = new URL(url, url.startsWith('/') ? window.location.href : undefined);
+
+      // Arbitrary setting of query param to stop caching from reusing any media requests which may have less headers
+      // cached than this request. This is to prevent a CORS error when the headers are different between partial
+      // content and full content requests.
+      newUrl.searchParams.set('t', '1');
+
+      xhr.open('GET', newUrl.toString(), true);
       xhr.send();
     });
   }


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change

When requesting urls for audio, it sometimes produces a CORS error after which it doesn't resolve and remains in error until the browser cache is cleared.
There is a problem with when the browser requests Partial Content for media based requests, having a completely different Header response than a full content Get request that is made. This eventually leads to the Partial Content request getting cached in the browser, and when trying to issue a Get request to that same url produces a CORS error. 


#### What does this fix?

This fix just puts a small query param added to **only** the Get requests made for the waveform data. It is small and deterministic purposefully so we don't ruin cache which would cause many more issues. This allows a differentiation between the Get requests made for waveform data of the audio files and the media requests (which we want to cache naturally for themselves, for both video and audio).



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Audio v3
