### PR TITLE
fix: LSDV-4692: Brush segmentation is not supported

### DIFF
--- a/src/mixins/DrawingTool.js
+++ b/src/mixins/DrawingTool.js
@@ -111,8 +111,6 @@ const DrawingTool = types
         self.currentArea = self.obj.createDrawingRegion(opts, resultValue, control, false);
         self.currentArea.setDrawing(true);
 
-        if (isFF(FF_LSDV_4583)) self.currentArea.setItemIndex?.(self.obj.currentImage);
-
         self.applyActiveStates(self.currentArea);
         self.annotation.setIsDrawing(true);
         return self.currentArea;
@@ -137,8 +135,6 @@ const DrawingTool = types
         }, { coordstype: 'px', dynamic: self.dynamic });
 
         const newArea = self.annotation.createResult(value, currentArea.results[0].value.toJSON(), control, obj);
-
-        if (isFF(FF_LSDV_4583)) newArea.setItemIndex?.(obj.currentImage);
 
         currentArea.setDrawing(false);
         self.applyActiveStates(newArea);

--- a/src/stores/Annotation/Annotation.js
+++ b/src/stores/Annotation/Annotation.js
@@ -839,8 +839,11 @@ export const Annotation = types
       };
 
 
-      //TODO: MST is crashing if we don't validate areas?, this problem isn't happening locally. So to reproduce you have to test in production or environment
+      // TODO: MST is crashing if we don't validate areas?, this problem isn't
+      // happening locally. So to reproduce you have to test in production or environment
       const area = self?.areas?.put(areaRaw);
+
+      object?.afterResultCreated?.(area);
 
       if (!area) return;
 

--- a/src/tags/object/Image/Image.js
+++ b/src/tags/object/Image/Image.js
@@ -515,6 +515,13 @@ const Model = types.model({
 
       createImageEntities();
     }
+  
+    function afterResultCreated(region) {
+      if (!region) return;
+      if (!self.multiImage) return;
+
+      region.setItemIndex?.(self.currentImage);
+    }
 
     function getToolsManager() {
       return manager;
@@ -523,6 +530,7 @@ const Model = types.model({
     return {
       afterAttach,
       getToolsManager,
+      afterResultCreated,
     };
   }).extend((self) => {
     let skipInteractions = false;


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
LSDV-4692



#### What does this fix?
Fixes Brush, Polygon, Ellipse and Keypoint in MIG scenario



#### What is the new behavior?
Regions created with Brush, Polygon, Ellipse or Keypoint tools are now displayed on respective images in the list.



#### What is the current behavior?
Regions created with one of the tools above were always displayed on the first image.



#### What libraries were added/updated?
None



#### Does this change affect performance?
No



#### Does this change affect security?
No



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Labeling UI, Image Segmentation, MIG