### PR TITLE
fix: LSDV-4776: Fix interpolating a video region rotation prop

### DIFF
--- a/src/regions/VideoRectangleRegion.js
+++ b/src/regions/VideoRectangleRegion.js
@@ -4,7 +4,8 @@ import NormalizationMixin from '../mixins/Normalization';
 import RegionsMixin from '../mixins/Regions';
 import Registry from '../core/Registry';
 import { AreaMixin } from '../mixins/AreaMixin';
-import { interpolateProp, onlyProps, VideoRegion } from './VideoRegion';
+import { onlyProps, VideoRegion } from './VideoRegion';
+import { interpolateProp } from '../utils/props';
 
 const Model = types
   .model('VideoRectangleRegionModel', {

--- a/src/regions/VideoRegion.js
+++ b/src/regions/VideoRegion.js
@@ -6,13 +6,6 @@ import { VideoModel } from '../tags/object/Video';
 import { guidGenerator } from '../core/Helpers';
 import { AreaMixin } from '../mixins/AreaMixin';
 
-export const interpolateProp = (start, end, frame, prop) => {
-  // @todo edge cases
-  const r = (frame - start.frame) / (end.frame - start.frame);
-
-  return start[prop] + (end[prop] - start[prop]) * r;
-};
-
 export const onlyProps = (props, obj) => {
   return Object.fromEntries(props.map(prop => [
     prop,

--- a/src/utils/__tests__/props.test.js
+++ b/src/utils/__tests__/props.test.js
@@ -1,0 +1,105 @@
+/* global describe, test, expect, it */
+
+import { interpolateProp, normalizeAngle } from '../props';
+
+describe('normalizeAngle', () => {
+  it('returns the same value for angle in the interval (-180; 180]', () => {
+    expect(normalizeAngle(-179.8)).toBe(-179.8);
+    expect(normalizeAngle(-42)).toBe(-42);
+    expect(normalizeAngle(0)).toBe(0);
+    expect(normalizeAngle(90)).toBe(90);
+    expect(normalizeAngle(180)).toBe(180);
+  });
+  it('projects angles from the intervals [-360;-180] and (180;360] onto the interval (-180; 180]', () => {
+    expect(normalizeAngle(-360)).toBe(0);
+    expect(normalizeAngle(-181)).toBe(179);
+    expect(normalizeAngle(220)).toBe(-140);
+    expect(normalizeAngle(359)).toBe(-1);
+  });
+});
+
+describe('interpolateProp', () => {
+  it('returns the exact value from the object containing the given frame', () => {
+    const objA = {
+      x: 0,
+      y: -50,
+      size: 100,
+      frame: 1,
+    };
+    const objB = {
+      x: 700,
+      y: -500,
+      size: 1,
+      frame: 100,
+    };
+
+    for (const prop of Object.keys(objA)) {
+      expect(interpolateProp(objA, objB, objA.frame, prop)).toBe(objA[prop]);
+      expect(interpolateProp(objA, objB, objB.frame, prop)).toBe(objB[prop]);
+    }
+  });
+  it('linearly interpolates numeric properties between frames', () => {
+    const objA = {
+      x: -10,
+      y: -50,
+      size: 3,
+      frame: 0,
+    };
+    const objB = {
+      x: 10,
+      y: -500,
+      size: 4,
+      frame: 100,
+    };
+
+    expect(interpolateProp(objA, objB, 25, 'x')).toBe(-5);
+    expect(interpolateProp(objA, objB, 50, 'x')).toBe(0);
+    expect(interpolateProp(objA, objB, 75, 'x')).toBe(5);
+    expect(interpolateProp(objA, objB, 8, 'y')).toBe(-86);
+    expect(interpolateProp(objA, objB, 30, 'y')).toBe(-185);
+    expect(interpolateProp(objA, objB, 72, 'y')).toBe(-374);
+    expect(interpolateProp(objA, objB, 50, 'size')).toBe(3.5);
+    expect(interpolateProp(objA, objB, 88, 'size')).toBe(3.88);
+    expect(interpolateProp(objA, objB, 3, 'size')).toBe(3.03);
+  });
+  it('linearly interpolates rotation in the shortest way', () => {
+    const objA = {
+      rotation: -170,
+      frame: 0,
+    };
+    const objB = {
+      rotation: 170,
+      frame: 20,
+    };
+
+    expect(interpolateProp(objA, objB, 0, 'rotation')).toBe(-170);
+    expect(interpolateProp(objA, objB, 5, 'rotation')).toBe(-175);
+    expect(interpolateProp(objA, objB, 10, 'rotation')).toBe(180);
+    expect(interpolateProp(objA, objB, 15, 'rotation')).toBe(175);
+    expect(interpolateProp(objA, objB, 20, 'rotation')).toBe(170);
+
+    expect(interpolateProp(objB, objA, 15, 'rotation')).toBe(175);
+
+    const objE = {
+      rotation: 180,
+      frame: 0,
+    };
+    const objN = {
+      rotation: 90,
+      frame: 10,
+    };
+    const objW = {
+      rotation: 0,
+      frame: 20,
+    };
+    const objS = {
+      rotation: -90,
+      frame: 30,
+    };
+
+    expect(interpolateProp(objE, objN, 5, 'rotation')).toBe(135);
+    expect(interpolateProp(objN, objW, 15, 'rotation')).toBe(45);
+    expect(interpolateProp(objW, objS, 25, 'rotation')).toBe(-45);
+    expect(interpolateProp(objS, objE, 15, 'rotation')).toBe(-135);
+  });
+});

--- a/src/utils/props.ts
+++ b/src/utils/props.ts
@@ -1,0 +1,25 @@
+/**
+ * project any angle onto the interval (-180;180]
+ */
+export function normalizeAngle(x:number) {
+  while(x > 0) x -= 360;
+  return (x - 180) % 360 + 180;
+}
+
+type SequenceItem = {
+  frame: number,
+  [k: string]: any,
+}
+
+/**
+ * interpolate prop between two sequence items
+ */
+export const interpolateProp = (start: SequenceItem, end: SequenceItem, frame:number, prop:string) => {
+  // @todo edge cases
+  const r = (frame - start.frame) / (end.frame - start.frame);
+
+  if (prop === 'rotation') {
+    return normalizeAngle(start[prop] + normalizeAngle(end[prop] - start[prop]) * r);
+  }
+  return start[prop] + (end[prop] - start[prop]) * r;
+};


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
[_(link to issue, supportive screenshots etc.)_](https://github.com/heartexlabs/label-studio/issues/3720)
Upside down regions can get wrong rotation prop interpolation while they go through 180deg bound.



#### What does this fix?
This should fix logic of interpolation of rotation value of video regions.



#### What libraries were added/updated?
N/A


#### Does this change affect performance?
No


#### Does this change affect security?
No


#### What alternative approaches were there?
N/A


#### What feature flags were used to cover this change?
N/A


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [x] unit



### Which logical domain(s) does this change affect?
Video, interpolation