### PR TITLE
fix: LSDV-4774: Drawing on the hidden image in MIG scenario

### DIFF
--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -86,6 +86,10 @@ const Regions = memo(({ regions, useLayers = true, chunkSize = 15, suggestion = 
 
 const DrawingRegion = observer(({ item }) => {
   const { drawingRegion } = item;
+  
+  if (!drawingRegion) return null;
+  if (item.multiImage && item.currentImage !== drawingRegion.item_index) return null;
+
   const Wrapper = drawingRegion && drawingRegion.type === 'brushregion' ? Fragment : Layer;
 
   return (

--- a/src/mixins/DrawingTool.js
+++ b/src/mixins/DrawingTool.js
@@ -347,6 +347,11 @@ const MultipleClicksDrawingTool = DrawingTool.named('MultipleClicksMixin')
         return Super.canStartDrawing() && !self.annotation.regionStore.hasSelection;
       },
       nextPoint(x, y) {
+        const area = self.getCurrentArea();
+        const object = self.obj;
+
+        if (area && object && object.multiImage && area.item_index !== object.currentImage) return;
+
         self.getCurrentArea().addPoint(x, y);
         pointsCount++;
       },

--- a/src/tools/Brush.js
+++ b/src/tools/Brush.js
@@ -182,9 +182,15 @@ const _Tool = types
         )
           return;
         const c = self.control;
+        const o = self.obj;
+
+        brush = self.getSelectedShape;
+
+        // prevent drawing when current image is
+        // different from image where the brush was started
+        if (o && brush && o.multiImage && o.currentImage !== brush.item_index) return;
 
         // Reset the timer if a user started drawing again
-        brush = self.getSelectedShape;
         if (brush && brush.type === 'brushregion') {
           self.annotation.history.freeze();
           self.mode = 'drawing';


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
LSDV-4774



#### What does this fix?
Fixes an issue when it's possible to start a Brush/Polygon region on one image and continue drawing on a different image.



#### What is the new behavior?
Regions created with Brush or Polygon will stay on the image they were initially created on. The user can continue drawing a region if they return to the image where they started. Otherwise, any drawings are ignored.



#### What is the current behavior?
If a user creates an unfinished Polygon and switches to the next image, the Polygon will travel to the next image as well. Whenever the Polygon is finished, it will stay on the last selected image.
If a user creates a Bush region, switches to the next image, and starts drawing, they won't see anything. As soon as they switch back to the previous image, they will see everything they drew on the second image. Effectively, they were drawing on an invisible image.



#### What libraries were added/updated?
None



#### Does this change affect performance?
No



#### Does this change affect security?
No



#### What alternative approaches were there?
None



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Labeling UI, Image Segmentation, MIG
