### PR TITLE
fix: LSDV-4898: Fix quick view is brotken when FF_DEV_3873 is on

### DIFF
--- a/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
@@ -73,6 +73,7 @@ const OutlinerStandAlone: FC<OutlinerPanelProps> = ({ regions, ...props }) => {
       <ViewControls
         grouping={regions.group}
         ordering={regions.sort}
+        regions={regions}
         orderingDirection={regions.sortOrder}
         onOrderingChange={onOrderingChange}
         onGroupingChange={onGroupingChange}


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
When FF_DEV_3873 is on, the Filter component is breaking the page quick view



#### What does this fix?
Add the property regions in the ViewControls when the FF_DEV_3873 is on, now this property is expected in the ViewControls component



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [x] unit
