### PR TITLE
test: LSDV-4943: Fix MIG Brush test

### DIFF
--- a/e2e/fragments/AtImageView.js
+++ b/e2e/fragments/AtImageView.js
@@ -10,6 +10,28 @@ module.exports = {
   _toolBarSelector: '.lsf-toolbar',
   _zoomPresetsSelector: '[title^="Zoom presets"]',
 
+  _rootSelector: '[class^="lsf-object wrapperComponent--"]',
+  _paginationSelector: '[class^="pagination--"]',
+  _paginationPrevBtnSelector: '.lsf-pagination__btn_arrow-left:not(.lsf-pagination__btn_arrow-left-double)',
+  _paginationNextBtnSelector: '.lsf-pagination__btn_arrow-right:not(.lsf-pagination__btn_arrow-right-double)',
+
+
+  locateRoot() {
+    return locate(this._rootSelector);
+  },
+
+  locate(locator) {
+    const rootLocator = this.locateRoot();
+
+    return locator ? rootLocator.find(locator) : rootLocator;
+  },
+
+  locatePagination(locator) {
+    const paginationLocator = this.locate(this._paginationSelector);
+
+    return locator ? paginationLocator.find(locator) : paginationLocator;
+  },
+
   percToX(xPerc) {
     return this._stageBBox.width * xPerc / 100;
   },
@@ -311,6 +333,18 @@ module.exports = {
   async multiImageGoBackwardWithHotkey() {
     I.say('Attempting to go to the next image');
     I.pressKey('Ctrl+a');
+
+    await this.waitForImage();
+  },
+
+  async multiImageGoForward() {
+    I.click(this.locatePagination(this._paginationNextBtnSelector));
+
+    await this.waitForImage();
+  },
+
+  async multiImageGoBackward() {
+    I.click(this.locatePagination(this._paginationPrevBtnSelector));
 
     await this.waitForImage();
   },

--- a/e2e/tests/image-list.test.js
+++ b/e2e/tests/image-list.test.js
@@ -277,7 +277,9 @@ Scenario('No errors during brush export in MIG', async ({ I, LabelStudio, AtImag
   AtLabels.clickLabel('Moonwalker');
   AtImageView.drawThroughPoints(brushRegionPoints);
 
-  await AtImageView.multiImageGoForwardWithHotkey();
+  // @todo: We cannot use these hotkeys due to duplicating regions action used the same hotkey
+  // await AtImageView.multiImageGoForwardWithHotkey();
+  await AtImageView.multiImageGoForward();
 
   I.pressKey('u');
   I.say('Create brush regions on the second image');


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
```
MIG
       No errors during brush export in MIG:

      3 == 2
      + expected - actual

      -3
      +2
```
`Ctrl`+`d` is used for duplicating selected region and going to the next page in the same time.
The test isn't failing every time, cause it can have enought time to use the hotkey before the brush region is created.


#### What does this fix?
It solve hotleys duplicating problem in test. 


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### Which logical domain(s) does this change affect?
tests