### PR TITLE
fix: LSDV-4953: Filter cut off at default panel width

### DIFF
--- a/src/components/SidePanels/OutlinerPanel/ViewControls.styl
+++ b/src/components/SidePanels/OutlinerPanel/ViewControls.styl
@@ -28,7 +28,6 @@
     position static
 
   .button
-    width 135px
     height 40px
     font-size 14px
     font-weight 400

--- a/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -63,12 +63,12 @@ export const ViewControls: FC<ViewControlsProps> = ({
     switch(value) {
       case 'date': return {
         label: 'Order by Time',
-        selectedLabel: 'Ordered by Time',
+        selectedLabel: 'By Time',
         icon: <IconDetails/>,
       };
       case 'score': return {
         label: 'Order by Score',
-        selectedLabel: 'Ordered by Score',
+        selectedLabel: 'By Score',
         icon: <IconSpeed/>,
       };
     }


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [X] Product design
- [X] Frontend



### Describe the reason for change
with manual grouping the text is too long and pushes the filter off of the visible area of the default width of panels 


#### What does this fix?
this change shortens the text of sort to allow for the filter to be visible 


#### What is the new behavior?
filter is visible 


#### What is the current behavior?
it is not visible 


#### What libraries were added/updated?
N/A


#### Does this change affect performance?
N/A


#### Does this change affect security?
N/A


#### What alternative approaches were there?
N/A


#### What feature flags were used to cover this change?
N/A


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
bug fix frontend new ui 