### PR TITLE
fix: LSDV-4960: Sort annotations by creation date instead of pk

### DIFF
--- a/src/components/AnnotationsCarousel/AnnotationsCarousel.tsx
+++ b/src/components/AnnotationsCarousel/AnnotationsCarousel.tsx
@@ -54,7 +54,7 @@ export const AnnotationsCarousel = observer(({ store, annotationStore }: Annotat
     <Block name='annotations-carousel' style={{ '--carousel-left': `${currentPosition}px` }}>
       <Elem ref={containerRef} name='container'>
         <Elem ref={carouselRef} name='carosel'>
-          {entities.sort((a, b) => a.pk - b.pk).map(entity => (
+          {entities.sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime()).map(entity => (
             <AnnotationButton 
               key={entity?.id} 
               entity={entity} 


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [X] Product design
- [X] Frontend



### Describe the reason for change
when new annotations are saved they moved from the front to the end of the list 


#### What does this fix?
this sorts the annotations by creation date 


#### What is the new behavior?
the annotations are saved in the order they are created 


#### What is the current behavior?
when a new annotation is a draft it is in the front of the list and moves to the end when submitted 


#### What libraries were added/updated?
N/A


#### Does this change affect performance?
N/A


#### Does this change affect security?
N/A


#### What alternative approaches were there?
N/A


#### What feature flags were used to cover this change?
N/A


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
annotations carousel 