### PR TITLE
fix: LSDV-3025-12: Fully hide the dropdown component when closing it

### DIFF
--- a/src/common/Dropdown/DropdownComponent.tsx
+++ b/src/common/Dropdown/DropdownComponent.tsx
@@ -23,6 +23,7 @@ export interface DropdownProps {
   enabled?: boolean;
   inline?: boolean;
   className?: string;
+  dataTestId?: string;
   style?: CSSProperties;
   children?: JSX.Element;
   onToggle?: (visible: boolean) => void;
@@ -79,8 +80,10 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(({
             setVisibility(visible ? 'before-appear' : 'before-disappear');
           },
           afterTransition: () => {
-            setVisibility(visible ? 'visible' : null);
-            resolve();
+            setTimeout(() => {
+              setVisibility(visible ? 'visible' : null);
+              resolve();
+            }, 100);
           },
         });
       });
@@ -197,6 +200,7 @@ export const Dropdown = forwardRef<DropdownRef, DropdownProps>(({
     <Block
       ref={dropdown}
       name="dropdown"
+      data-testid={props.dataTestId}
       mix={[props.className, visibilityClasses]}
       style={compositeStyles}
       onClick={(e: MouseEvent) => e.stopPropagation()}

--- a/src/common/Dropdown/DropdownTrigger.tsx
+++ b/src/common/Dropdown/DropdownTrigger.tsx
@@ -28,6 +28,7 @@ interface DropdownTriggerProps extends DropdownProps {
   tag?: string;
   dropdown?: RefObject<JSX.Element>;
   content?: JSX.Element;
+  dataTestId?: string;
   toggle?: boolean;
   closeOnClickOutside?: boolean;
   disabled?: boolean;

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -14,6 +14,7 @@ export const Filter: FC<FilterInterface> = ({
   availableFilters,
   filterData,
   onChange,
+  animated = true,
 }) => {
   const [filterList, setFilterList] = useState<FilterListInterface[]>([]);
 
@@ -103,6 +104,8 @@ export const Filter: FC<FilterInterface> = ({
   return (
     <Dropdown.Trigger
       content={renderFilter}
+      dataTestId={'dropdown'}
+      animated={animated}
     >
       <Button data-cy={'filter-button'} type="text" style={{ padding: 0, whiteSpace: 'nowrap' }}>
         <Elem name={'icon'}>

--- a/src/components/Filter/FilterInterfaces.tsx
+++ b/src/components/Filter/FilterInterfaces.tsx
@@ -7,6 +7,8 @@ export interface FilterInterface {
   availableFilters: AvailableFiltersInterface[];
   onChange: (filter: any) => void;
   filterData: any;
+
+  animated?: boolean;
 }
 
 export interface FilterListInterface {

--- a/src/components/Filter/__tests__/Filter.test.tsx
+++ b/src/components/Filter/__tests__/Filter.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Filter } from '../Filter';
+import { act } from 'react-dom/test-utils';
 
 describe('Filter', () => {
   const mockOnChange = jest.fn();
+
   const filterData = [
     {
       'labelName': 'AirPlane',
@@ -123,5 +125,45 @@ describe('Filter', () => {
 
 
     expect(filteredContent).toStrictEqual([{ labelName: 'Car' }, { labelName: 'AirCar' }]) ;
+  });
+
+  test('Should hide dropdown filter', async () => {
+    const filter = render(<Filter
+      onChange={mockOnChange}
+      filterData={filterData}
+      animated={false}
+      availableFilters={[{
+        label: 'Annotation results',
+        path: 'labelName',
+        type: 'String',
+      },
+      {
+        label: 'Confidence score',
+        path: 'score',
+        type: 'Number',
+      }]}
+    />);
+
+    const FilterButton = await filter.getByText('Filter');
+
+    fireEvent.click(FilterButton);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const dropdown = await filter.getByTestId('dropdown');
+
+    expect(dropdown.classList.contains('dm-visible')).toBe(true);
+
+    const AddButton = await filter.getByText('Add Filter');
+
+    fireEvent.click(AddButton);
+
+    fireEvent.click(FilterButton);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(dropdown.classList.contains('dm-before-appear')).toBe(false);
+    expect(dropdown.classList.contains('dm-visible')).toBe(false);
+    expect(dropdown.classList.contains('dm-before-disappear')).toBe(false);
   });
 });


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The dropdown component is not hidden enterally, there is a small timeout that is making the transition method is being triggered before afterTransition. And it is making the dropdown is being clickable even after it's hidden.


#### Does this change affect performance?
no



#### Does this change affect security?
no



#### What alternative approaches were there?
na



#### What feature flags were used to cover this change?
na



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [x] unit

