### PR TITLE
fix: LSDV-4998: Fix missed dynamic children on task switch

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -15,8 +15,9 @@ import Settings from './SettingsStore';
 import Task from './TaskStore';
 import { UserExtended } from './UserStore';
 import { UserLabels } from './UserLabels';
-import { FF_DEV_1536, FF_DEV_2715, isFF } from '../utils/feature-flags';
+import { FF_DEV_1536, FF_DEV_2715, FF_LSDV_4998, isFF } from '../utils/feature-flags';
 import { CommentStore } from './Comment/CommentStore';
+import { destroy as destroySharedStore } from '../mixins/SharedChoiceStore/mixin';
 
 const hotkeys = Hotkey('AppStore', 'Global Hotkeys');
 
@@ -600,6 +601,9 @@ export default types
 
       if (oldAnnotationStore) {
         oldAnnotationStore.beforeReset?.();
+        if (isFF(FF_LSDV_4998)) {
+          destroySharedStore();
+        }
         detach(oldAnnotationStore);
         destroy(oldAnnotationStore);
       }

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -238,6 +238,15 @@ export const FF_LSDV_4832 = 'fflag_feat_front_lsdv_4832_new_ranker_tag_120423_sh
  */
 export const FF_LSDV_4881 = 'fflag_fix_front_lsdv_4881_timeseries_points_missing_140423_short';
 
+/**
+ * Resetting shared stores on task change to correctly generate dynamic children
+ *
+ * @see: ff_dev_2007_dev_2008_dynamic_tag_children_250322_short: To enable dynamic children
+ * @see: fflag_fix_front_dev_3617_taxonomy_memory_leaks_fix: To enable shared store
+ * @link https://app.launchdarkly.com/default/production/features/fflag_fix_front_lsdv_4998_missed_dynamic_children_030523_short
+ */
+export const FF_LSDV_4998 = 'fflag_fix_front_lsdv_4998_missed_dynamic_children_030523_short';
+
 Object.assign(window, {
   APP_SETTINGS: {
     ...(window.APP_SETTINGS ?? {}),


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
Shared store do not work with dynamic children of Taxonomy. Taxonomy does not update its children between different tasks.

#### What does this fix?
This fix reset shared storage on task switching to prevent stucking irrelevant dynamic children

#### Does this change affect performance?
Maybe...



#### Does this change affect security?
N/A



#### What alternative approaches were there?
The other approach is moving stories to the annotation level.
It's much harder to do, and does not seem necessary.

#### What feature flags were used to cover this change?
`fflag_fix_front_lsdv_4998_missed_dynamic_children_030523_short`

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`Taxonomy`, `Dynamic Children`
