### PR TITLE
fix: Modified to adapt horizontally long images.

### DIFF
--- a/src/tags/object/Image/Image.js
+++ b/src/tags/object/Image/Image.js
@@ -83,7 +83,7 @@ const TagAttrs = types.model({
   valuelist: types.maybeNull(types.string),
   resize: types.maybeNull(types.number),
   width: types.optional(types.string, '100%'),
-  height: types.maybeNull(types.string),
+  height: types.optional(types.string, 'calc(100vh - 194px)'),
   maxwidth: types.optional(types.string, '100%'),
   maxheight: types.optional(types.string, 'calc(100vh - 194px)'),
   smoothing: types.maybeNull(types.boolean),


### PR DESCRIPTION
### PR fulfills these requirements
- [ ] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)


#### Change has impacts in these area(s)
- [ ] Product design
- [x] Frontend


### Describe the reason for change
In a horizontally long image, the area visible is narrow when zoomed in.


#### What does this fix?
The default value of `maxheight` is set to the default value of `X`.


#### What is the new behavior?

https://user-images.githubusercontent.com/9734203/236177846-e0aa56f2-8f9f-4ca1-9c18-e2a352f8e6aa.mp4


#### What is the current behavior?

https://user-images.githubusercontent.com/9734203/236177355-75cfabe2-3948-4933-8b17-efd607d66c98.mp4


#### What libraries were added/updated?
No libraries.

#### Does this change affect performance?
Maybe no.


#### Does this change affect security?
No.

#### What alternative approaches were there?
Maybe no.


#### What feature flags were used to cover this change?
N/A



### Does this PR introduce a breaking change?
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)


### What level of testing was included in the change?
- [ ] e2e
- [ ] integration
- [ ] unit


### Which logical domain(s) does this change affect?
Pages that be able to zoom in on images.
