### PR TITLE
fix: LSDV-5031: Adding new region after filter it is not filtered

### DIFF
--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -19,7 +19,7 @@ export const Filter: FC<FilterInterface> = ({
 
   useEffect(() => {
     if(filterList.length > 0) {
-      onChange(FilterItems(filterData, filterList[0]));
+      onChange(FilterItems(filterData, filterList));
     }
   }, [filterData]);
 

--- a/src/stores/RegionStore.js
+++ b/src/stores/RegionStore.js
@@ -430,7 +430,6 @@ export default types.model('RegionStore', {
   setView(view) {
     if (isFF(FF_DEV_2755)) {
       window.localStorage.setItem(localStorageKeys.view, view);
-      console.log('setView', window.localStorage.getItem(localStorageKeys.view));
     }
     self.view = view;
   },
@@ -455,15 +454,21 @@ export default types.model('RegionStore', {
   },
 
   setFilteredRegions(filter) {
-    self.filter = filter;
 
-    const filteredIds = filter.map((filter) => filter.id);
-    
-    self.regions.forEach((region) => {
-      if (!region.hideable || (region.hidden && !region.filtered)) return;
-      if (filteredIds.includes(region.id)) region.hidden && region.toggleFiltered();
-      else if (!region.hidden) region.toggleFiltered();
-    });
+    if (self.regions.length === filter.length) {
+      self.filter = null;
+      self.regions.forEach((region) => region.filtered && region.toggleFiltered());
+    } else {
+      const filteredIds = filter.map((filter) => filter.id);
+      
+      self.filter = filter;
+
+      self.regions.forEach((region) => {
+        if (!region.hideable || (region.hidden && !region.filtered)) return;
+        if (filteredIds.includes(region.id)) region.hidden && region.toggleFiltered();
+        else if (!region.hidden) region.toggleFiltered();
+      });
+    }
   },
 
   /**


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
When filtering and then adding regions the new regions would not appear in the outliner 


#### What does this fix?
This clears out the filter when it is empty so that new additions will be included 


#### What is the new behavior?
The filters is applied to new regions and when deleted it is applied to none


#### What is the current behavior?
The filter becomes a list of all the regions when deleted which does not include new additions


#### What libraries were added/updated?
none


#### Does this change affect performance?
no


#### Does this change affect security?
no


#### What alternative approaches were there?
no


#### What feature flags were used to cover this change?
none


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Regions filters in the outliner