### PR TITLE
feat: PROD-309: Add hint for Choice

### DIFF
--- a/src/common/Tooltip/Tooltip.tsx
+++ b/src/common/Tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@ export interface TooltipProps {
   children: JSX.Element;
   theme?: 'light' | 'dark';
   defaultVisible?: boolean;
+  // activates intent detecting mode
   mouseEnterDelay?: number;
   enabled?: boolean;
   style?: CSSProperties;
@@ -38,6 +39,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
   const [visibility, setVisibility] = useState(defaultVisible ? 'visible' : null);
   const [injected, setInjected] = useState(false);
   const [align, setAlign] = useState<ElementAlignment>('top-center');
+  const mouseEnterTimeoutRef = useRef<number|undefined>();
 
   const calculatePosition = useCallback(() => {
     const { left, top, align: resultAlign } = alignElements(
@@ -121,7 +123,8 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
     const handleTooltipAppear = () => {
       if (enabled === false) return;
 
-      setTimeout(() => {
+      mouseEnterTimeoutRef.current = window.setTimeout(() => {
+        mouseEnterTimeoutRef.current = undefined;
         setInjected(true);
       }, mouseEnterDelay);
     };
@@ -129,6 +132,10 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
     const handleTooltipHiding = () => {
       if (enabled === false) return;
 
+      if (mouseEnterTimeoutRef.current) {
+        window.clearTimeout(mouseEnterTimeoutRef.current);
+        mouseEnterTimeoutRef.current = undefined;
+      }
       performAnimation(false);
     };
 

--- a/src/common/Tooltip/Tooltip.tsx
+++ b/src/common/Tooltip/Tooltip.tsx
@@ -133,8 +133,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
       if (enabled === false) return;
 
       if (mouseEnterTimeoutRef.current) {
-        window.clearTimeout(mouseEnterTimeoutRef.current);
-        mouseEnterTimeoutRef.current = undefined;
+        mouseEnterTimeoutRef.current = window.clearTimeout(mouseEnterTimeoutRef.current);
       }
       performAnimation(false);
     };

--- a/src/common/Tooltip/Tooltip.tsx
+++ b/src/common/Tooltip/Tooltip.tsx
@@ -14,6 +14,8 @@ export interface TooltipProps {
   mouseEnterDelay?: number;
   enabled?: boolean;
   style?: CSSProperties;
+  // allows to convert triggerElementRef into a real HTMLElement for listeners and getting bbox
+  triggerElementGetter?: (refValue:any)=>HTMLElement;
 }
 
 export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
@@ -24,6 +26,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
   enabled = true,
   theme = 'dark',
   style,
+  triggerElementGetter = refValue => refValue as HTMLElement,
 }, ref) => {
   if (!children || Array.isArray(children)) {
     throw new Error('Tooltip does accept a single child only');
@@ -38,7 +41,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
 
   const calculatePosition = useCallback(() => {
     const { left, top, align: resultAlign } = alignElements(
-      triggerElement.current,
+      triggerElementGetter(triggerElement.current),
       tooltipElement.current!,
       align,
       10,
@@ -113,7 +116,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(({
   }, [injected]);
 
   useEffect(() => {
-    const el = triggerElement.current;
+    const el = triggerElementGetter(triggerElement.current);
 
     const handleTooltipAppear = () => {
       if (enabled === false) return;

--- a/src/components/Taxonomy/Taxonomy.tsx
+++ b/src/components/Taxonomy/Taxonomy.tsx
@@ -1,4 +1,12 @@
-import React, { FormEvent, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  FormEvent,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { Dropdown, Menu } from 'antd';
 
 import { useToggle } from '../../hooks/useToggle';
@@ -7,7 +15,9 @@ import { LsChevron } from '../../assets/icons';
 import TreeStructure from '../TreeStructure/TreeStructure';
 
 import styles from './Taxonomy.module.scss';
-import { FF_DEV_4075, isFF } from '../../utils/feature-flags';
+import { FF_DEV_4075, FF_PROD_309, isFF } from '../../utils/feature-flags';
+import { Tooltip } from '../../common/Tooltip/Tooltip';
+import { CNTagName } from '../../utils/bem';
 
 type TaxonomyPath = string[];
 type onAddLabelCallback = (path: string[]) => any;
@@ -19,6 +29,7 @@ type TaxonomyItem = {
   depth: number,
   children?: TaxonomyItem[],
   origin?: 'config' | 'user' | 'session',
+  hint?: string,
 };
 
 type TaxonomyOptions = {
@@ -74,6 +85,7 @@ interface RowProps {
       padding: number,
       isLeaf: boolean,
       origin?: any,
+      hint?: string,
     },
     children?: any,
     toggle: (id: string) => void,
@@ -148,9 +160,37 @@ function isSubArray(item: string[], parent: string[]) {
   return parent.every((n, i) => item[i] === n);
 }
 
+type HintTooltipProps = {
+  // Without title there is no tooltip at all as a component
+  title?: string,
+  // wrapper is used as a tag in JSX to wrap child elements to make Tooltip to work with the single child element
+  // it can be a real tag or a component that provides real HTMLElement (not a text) as the result
+  wrapper?: CNTagName,
+  children: JSX.Element,
+}
+
+export const HintTooltip: React.FC<HintTooltipProps>  = ({
+  title,
+  wrapper: Wrapper, children,
+  ...rest
+}) => {
+  if (!isFF(FF_PROD_309)) return children;
+  
+  const content = Wrapper ? <Wrapper>{children}</Wrapper> : children;
+
+  if (title) {
+    return (
+      <Tooltip title={title} {...rest}>
+        {content}
+      </Tooltip>
+    );
+  }
+  return content;
+};
+
 const Item: React.FC<RowProps> = ({ style, item, dimensionCallback, maxWidth, isEditable }: RowProps) => {
   const {
-    row: { id, isOpen, childCount, isFiltering, name, path, padding, isLeaf },
+    row: { id, isOpen, childCount, isFiltering, name, path, padding, isLeaf, hint },
     toggle,
     addInside: addChild,
   } = item;
@@ -222,67 +262,69 @@ const Item: React.FC<RowProps> = ({ style, item, dimensionCallback, maxWidth, is
               </div>
             )}
           </div>
-          <div className={[styles.taxonomy__item, customClassname].join(' ')}>
-            <div className={styles.taxonomy__grouping} onClick={() => toggle(id)}>
-              <LsChevron stroke="#09f" style={arrowStyle} />
-            </div>
-            <input
-              className="item"
-              id={id}
-              name={id}
-              type="checkbox"
-              disabled={disabled}
-              checked={checked}
-              ref={setIndeterminate}
-              onChange={e => {
-                if (isEditable) {
-                  setSelected(path, e.currentTarget.checked);
-                }
-              }}
-            />
-            <label
-              htmlFor={id}
-              style={isFF(FF_DEV_4075) ? {} : { maxWidth: `${labelMaxWidth}px` }}
-              onClick={isEditable ? onClick : undefined}
-              title={title}
-              className={disabled ? styles.taxonomy__collapsable : undefined}
-            >
-              {name}
-            </label>
-            {!isFiltering && (
-              <div className={styles.taxonomy__extra}>
-                <span className={styles.taxonomy__extra_count}>{childCount}</span>
-                {isEditable && onAddLabel && (
-                  <div className={styles.taxonomy__extra_actions}>
-                    <Dropdown
-                      destroyPopupOnHide // important for long interactions with huge taxonomy
-                      trigger={['click']}
-                      overlay={(
-                        <Menu>
-                          <Menu.Item
-                            key="add-inside"
-                            className={styles.taxonomy__action}
-                            onClick={() => {
-                              addChild(id);
-                            }}
-                          >
-                            Add Inside
-                          </Menu.Item>
-                          {item.row.origin === 'session' && (
-                            <Menu.Item key="delete" className={styles.taxonomy__action} onClick={onDelete}>
-                              Delete
-                            </Menu.Item>
-                          )}
-                        </Menu>
-                      )}
-                    >
-                      <div>...</div>
-                    </Dropdown>
-                  </div>
-                )}
+          <HintTooltip title={hint}>
+            <div className={[styles.taxonomy__item, customClassname].join(' ')}>
+              <div className={styles.taxonomy__grouping} onClick={() => toggle(id)}>
+                <LsChevron stroke="#09f" style={arrowStyle} />
               </div>
-            )}
-          </div>
+              <input
+                className="item"
+                id={id}
+                name={id}
+                type="checkbox"
+                disabled={disabled}
+                checked={checked}
+                ref={setIndeterminate}
+                onChange={e => {
+                  if (isEditable) {
+                    setSelected(path, e.currentTarget.checked);
+                  }
+                }}
+              />
+              <label
+                htmlFor={id}
+                style={isFF(FF_DEV_4075) ? {} : { maxWidth: `${labelMaxWidth}px` }}
+                onClick={isEditable ? onClick : undefined}
+                title={title}
+                className={disabled ? styles.taxonomy__collapsable : undefined}
+              >
+                {name}
+              </label>
+              {!isFiltering && (
+                <div className={styles.taxonomy__extra}>
+                  <span className={styles.taxonomy__extra_count}>{childCount}</span>
+                  {isEditable && onAddLabel && (
+                    <div className={styles.taxonomy__extra_actions}>
+                      <Dropdown
+                        destroyPopupOnHide // important for long interactions with huge taxonomy
+                        trigger={['click']}
+                        overlay={(
+                          <Menu>
+                            <Menu.Item
+                              key="add-inside"
+                              className={styles.taxonomy__action}
+                              onClick={() => {
+                                addChild(id);
+                              }}
+                            >
+                            Add Inside
+                            </Menu.Item>
+                            {item.row.origin === 'session' && (
+                              <Menu.Item key="delete" className={styles.taxonomy__action} onClick={onDelete}>
+                              Delete
+                              </Menu.Item>
+                            )}
+                          </Menu>
+                        )}
+                      >
+                        <div>...</div>
+                      </Dropdown>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </HintTooltip>
         </>
       ) : (
         <UserLabelForm key="" onAddLabel={onAddLabel} onFinish={() => addChild()} path={path} />
@@ -358,7 +400,7 @@ const TaxonomyDropdown = ({ show, flatten, items, dropdownRef, isEditable }: Tax
   }, [show]);
 
   const dataTransformation = ({
-    node: { children, depth, label, origin, path },
+    node: { children, depth, label, origin, path, hint },
     nestingLevel,
     isFiltering,
     isOpen,
@@ -381,6 +423,7 @@ const TaxonomyDropdown = ({ show, flatten, items, dropdownRef, isEditable }: Tax
     origin,
     padding: nestingLevel * 10 + 10,
     path,
+    hint,
   });
 
   return (

--- a/src/components/Taxonomy/Taxonomy.tsx
+++ b/src/components/Taxonomy/Taxonomy.tsx
@@ -171,7 +171,8 @@ type HintTooltipProps = {
 
 export const HintTooltip: React.FC<HintTooltipProps>  = ({
   title,
-  wrapper: Wrapper, children,
+  wrapper: Wrapper,
+  children,
   ...rest
 }) => {
   if (!isFF(FF_PROD_309)) return children;

--- a/src/components/Taxonomy/Taxonomy.tsx
+++ b/src/components/Taxonomy/Taxonomy.tsx
@@ -180,7 +180,7 @@ export const HintTooltip: React.FC<HintTooltipProps>  = ({
 
   if (title) {
     return (
-      <Tooltip title={title} {...rest}>
+      <Tooltip title={title} mouseEnterDelay={500} {...rest}>
         {content}
       </Tooltip>
     );

--- a/src/tags/control/Choices.js
+++ b/src/tags/control/Choices.js
@@ -22,6 +22,7 @@ import DynamicChildrenMixin from '../../mixins/DynamicChildrenMixin';
 import { FF_DEV_2007, FF_DEV_2007_DEV_2008, isFF } from '../../utils/feature-flags';
 import { ReadOnlyControlMixin } from '../../mixins/ReadOnlyMixin';
 import SelectedChoiceMixin from '../../mixins/SelectedChoiceMixin';
+import { HintTooltip } from '../../components/Taxonomy/Taxonomy';
 
 const { Option } = Select;
 
@@ -277,7 +278,9 @@ const ChoicesSelectLayout = observer(({ item }) => {
     >
       {item.tiedChildren.map(i => (
         <Option key={i._value} value={i._value}>
-          {i._value}
+          <HintTooltip title={i.hint} wrapper="div">
+            {i._value}
+          </HintTooltip>
         </Option>
       ))}
     </Select>

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -215,6 +215,10 @@ const Model = types
       }
     },
 
+    beforeDestroy() {
+      ChildrenSnapshots.delete(self.name);
+    },
+
     updateChildren() {
       const children = ChildrenSnapshots.get(self.name) ?? [];
 

--- a/src/tags/control/Taxonomy/Taxonomy.js
+++ b/src/tags/control/Taxonomy/Taxonomy.js
@@ -83,9 +83,10 @@ function traverse(root) {
 
   const visitNode = function(node, parents = []) {
     const label = node.value;
+    const hint = node.hint;
     const path = [...parents, node.alias ?? label];
     const depth = parents.length;
-    const obj = { label, path, depth };
+    const obj = { label, path, depth, hint };
 
     if (node.children) {
       obj.children = visitUnique(node.children, path);

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -247,6 +247,12 @@ export const FF_LSDV_4881 = 'fflag_fix_front_lsdv_4881_timeseries_points_missing
  */
 export const FF_LSDV_4998 = 'fflag_fix_front_lsdv_4998_missed_dynamic_children_030523_short';
 
+/**
+ * Add ability to show hints while hover over the choice
+ * @see: ff_dev_2007_rework_choices_280322_short: To enable alt version of <Choices/> (it's not necessary)
+ */
+export const FF_PROD_309 = 'fflag_feat_front_prod_309_choice_hint_080523_short';
+
 Object.assign(window, {
   APP_SETTINGS: {
     ...(window.APP_SETTINGS ?? {}),

--- a/tests/functional/data/control_tags/choice.ts
+++ b/tests/functional/data/control_tags/choice.ts
@@ -1,0 +1,29 @@
+export const simpleData = {
+  text: 'This text exists for no reason',
+};
+export const choicesConfig = `<View>
+  <Text name="text"/>
+  <Choices name="choices" choice="single">
+    <Choice value="Choice 1" />
+    <Choice value="Choice 2" hint="A hint for Choice 2" />
+    <Choice value="Choice 3" />
+  </Choices>
+</View>`;
+
+export const choicesMultipleSelectionConfig = `<View>
+  <Text name="text"/>
+  <Choices name="choices" choice="multiple">
+    <Choice value="Choice 1" />
+    <Choice value="Choice 2" hint="A hint for Choice 2" />
+    <Choice value="Choice 3" />
+  </Choices>
+</View>`;
+
+export const choicesSelectLayoutConfig = `<View>
+  <Text name="text"/>
+  <Choices name="choices" layout="select" choice="multiple">
+    <Choice value="Choice 1" />
+    <Choice value="Choice 2" hint="A hint for Choice 2" />
+    <Choice value="Choice 3" />
+  </Choices>
+</View>`;

--- a/tests/functional/data/control_tags/taxonomy.ts
+++ b/tests/functional/data/control_tags/taxonomy.ts
@@ -1,0 +1,11 @@
+export const simpleData = {
+  text: 'This text exists for no reason',
+};
+export const taxonomyConfig = `<View>
+  <Text name="text"/>
+  <Taxonomy name="choices">
+    <Choice value="Choice 1" />
+    <Choice value="Choice 2" hint="A hint for Choice 2" />
+    <Choice value="Choice 3" />
+  </Taxonomy>
+</View>`;

--- a/tests/functional/feature-flags.ts
+++ b/tests/functional/feature-flags.ts
@@ -2,5 +2,6 @@ import * as FLAGS from '../../src/utils/feature-flags';
 
 export const CURRENT_FLAGS = {
   [FLAGS.FF_DEV_1170]: true,
+  [FLAGS.FF_PROD_309]: true,
 };
 

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -18,7 +18,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#09521e0"
+    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#82047b8"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -18,7 +18,7 @@
     "cvg:summary": "nyc report --temp-dir=.nyc_output --reporter=text-summary --cwd=. --exclude-after-remap false"
   },
   "dependencies": {
-    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#82047b8"
+    "@heartexlabs/ls-test": "git+ssh://git@github.com/heartexlabs/ls-frontend-test#12fb08d"
   },
   "devDependencies": {
     "ts-loader": "^9.4.2",

--- a/tests/functional/specs/control_tags/choice.cy.ts
+++ b/tests/functional/specs/control_tags/choice.cy.ts
@@ -1,0 +1,79 @@
+import { Choices, LabelStudio, Tooltip } from '@heartexlabs/ls-test/helpers/LSF/index';
+import {
+  choicesConfig,
+  choicesMultipleSelectionConfig, choicesSelectLayoutConfig,
+  simpleData
+} from 'data/control_tags/choice';
+import { FF_DEV_2007 } from '@heartexlabs/ls-test/feature-flags';
+
+describe('Control Tags - Choice', () => {
+  describe('Old version', () => {
+    beforeEach(() => {
+      LabelStudio.addFeatureFlagsOnPageLoad({
+        [FF_DEV_2007]: false,
+      });
+    });
+
+    it('should show hint for <Choice /> when choice="single"', () => {
+      LabelStudio.params()
+        .config(choicesConfig)
+        .data(simpleData)
+        .withResult([])
+        .init();
+
+      Choices.findChoice('Choice 2').trigger('mouseenter');
+      Tooltip.hasText('A hint for Choice 2');
+    });
+    it('should show hint for <Choice /> when choice="multiple"', () => {
+      LabelStudio.params()
+        .config(choicesMultipleSelectionConfig)
+        .data(simpleData)
+        .withResult([])
+        .init();
+
+      Choices.findChoice('Choice 2').trigger('mouseenter');
+      Tooltip.hasText('A hint for Choice 2');
+    });
+    it('should show hint for <Choice /> when layout="select"', () => {
+      LabelStudio.params()
+        .config(choicesSelectLayoutConfig)
+        .data(simpleData)
+        .withResult([])
+        .init();
+
+      Choices.toggleSelect();
+      Choices.findOption('Choice 2').trigger('mouseenter');
+      Tooltip.hasText('A hint for Choice 2');
+    });
+  });
+
+  describe('New version', () => {
+    beforeEach(() => {
+      LabelStudio.addFeatureFlagsOnPageLoad({
+        [FF_DEV_2007]: true,
+      });
+    });
+
+    it('should show hint for <Choise />', () => {
+      LabelStudio.params()
+        .config(choicesConfig)
+        .data(simpleData)
+        .withResult([])
+        .init();
+
+      Choices.findChoice('Choice 2').trigger('mouseenter');
+      Tooltip.hasText('A hint for Choice 2');
+    });
+
+    it('should show hint for <Choise />', () => {
+      LabelStudio.params()
+        .config(choicesMultipleSelectionConfig)
+        .data(simpleData)
+        .withResult([])
+        .init();
+
+      Choices.findChoice('Choice 2').trigger('mouseenter');
+      Tooltip.hasText('A hint for Choice 2');
+    });
+  });
+});

--- a/tests/functional/specs/control_tags/taxonomy.cy.ts
+++ b/tests/functional/specs/control_tags/taxonomy.cy.ts
@@ -1,0 +1,16 @@
+import { LabelStudio, Taxonomy, Tooltip } from '@heartexlabs/ls-test/helpers/LSF/index';
+import { simpleData, taxonomyConfig } from '../../data/control_tags/taxonomy';
+
+describe('Control Tags - Taxonomy', () => {
+  it('should show hint for <Choice />', () => {
+    LabelStudio.params()
+      .config(taxonomyConfig)
+      .data(simpleData)
+      .withResult([])
+      .init();
+
+    Taxonomy.open();
+    Taxonomy.findItem('Choice 2').trigger('mouseenter');
+    Tooltip.hasText('A hint for Choice 2');
+  });
+});

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -264,9 +264,9 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#09521e0":
+"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#12fb08d":
   version "1.0.8"
-  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#09521e06a1d5f8672ef6cd0385cda3d485368044"
+  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#12fb08d18907b6eda0b184a38fc1c2b989e3ba8d"
   dependencies:
     "@cypress/code-coverage" "^3.10.0"
     "@cypress/webpack-preprocessor" "^5.17.0"

--- a/tests/functional/yarn.lock
+++ b/tests/functional/yarn.lock
@@ -284,6 +284,26 @@
     webpack-cli "^5.0.1"
     yargs "^17.7.1"
 
+"@heartexlabs/ls-test@git+ssh://git@github.com/heartexlabs/ls-frontend-test#82047b8":
+  version "1.0.8"
+  resolved "git+ssh://git@github.com/heartexlabs/ls-frontend-test#82047b8f9b7d2da74a40d824350e736f6520ce0f"
+  dependencies:
+    "@cypress/code-coverage" "^3.10.0"
+    "@cypress/webpack-preprocessor" "^5.17.0"
+    chai "^4.3.7"
+    cypress "^12.9.0"
+    cypress-multi-reporters "^1.6.2"
+    cypress-parallel "^0.12.0"
+    cypress-plugin-snapshots "^1.4.4"
+    cypress-terminal-report "^5.1.1"
+    pixelmatch "^5.3.0"
+    pngjs "^7.0.0"
+    ts-loader "^9.4.2"
+    typescript "^4.9.5"
+    webpack "^5.77.0"
+    webpack-cli "^5.0.1"
+    yargs "^17.7.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
We have this functionality for `<Label/>` tag and it would be fair to add to choices too.


#### What is the new behavior?
A new `hint` parameter for `<Choice/>` allows to add informative hints in form of tooltips for each `Choice` element in each containers' mode.


#### What libraries were added/updated?
`@heartexlabs/ls-test`


#### Does this change affect performance?
N/A



#### Does this change affect security?
N/A



#### What alternative approaches were there?
N/A



#### What feature flags were used to cover this change?
`fflag_feat_front_prod_309_choice_hint_080523_short`



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [x] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`Choice`, `Choices`, `Taxonomy`, `Tooltip`
