### PR TITLE
fix: LSDV-5090: Hidden regions notifications is displaying when filter is applied

### DIFF
--- a/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
@@ -26,6 +26,10 @@ const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) =
     regions.setFilteredRegions(value);
   }, [regions]);
 
+  const hiddenRegions = useMemo(() => {
+    return regions?.regions?.length - regions?.filter?.length;
+  }, [regions?.regions?.length, regions?.filter?.length]);
+
   useEffect(() => {
     setGroup(regions.group);
   }, []);
@@ -43,14 +47,29 @@ const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) =
         onGroupingChange={onGroupingChange}
         onFilterChange={onFilterChange}
       />
-      {regions?.regions?.length > 0 ? (
-        <OutlinerTree
-          regions={regions}
-          selectedKeys={regions.selection.keys}
-        />
+      {(regions?.regions?.length > 0 && regions?.filter?.length === 0) ? (
+        <Elem name="filters-empty">
+          <IconInfo width={21} height={20} />
+          <Elem name="filters-title">All regions hidden</Elem>
+          <Elem name="filters-description">Adjust or remove the filters to view</Elem>
+        </Elem>
+      ) : regions?.regions?.length > 0 ? (
+        <>
+          <OutlinerTree
+            regions={regions}
+            selectedKeys={regions.selection.keys}
+          />
+          {hiddenRegions > 0 && (
+            <Elem name="filters-empty">
+              <IconInfo width={21} height={20} />
+              <Elem name="filters-title">There {hiddenRegions === 1 ? 'is' : 'are'} {hiddenRegions} hidden region{hiddenRegions > 1 && 's'}</Elem>
+              <Elem name="filters-description">Adjust or remove filters to view</Elem>
+            </Elem>
+          )}
+        </>
       ) : (
         <Elem name="empty">
-          Regions not added
+            Regions not added
         </Elem>
       )}
     </PanelBase>
@@ -71,7 +90,7 @@ const OutlinerStandAlone: FC<OutlinerPanelProps> = ({ regions }) => {
   }, [regions]);
 
   const hiddenRegions = useMemo(() => {
-    return (regions?.regions?.length ?? 0) - (regions?.filter?.length ?? 0);
+    return regions?.regions?.length - regions?.filter?.length;
   }, [regions?.regions?.length, regions?.filter?.length]);
 
   return (

--- a/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
@@ -114,7 +114,7 @@ const OutlinerTreeComponent: FC<OutlinerTreeComponentProps> = observer(({ region
         </>
       ) : (
         <Elem name="empty">
-            Regions not added
+          Regions not added
         </Elem>
       )}
     </>

--- a/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
+++ b/src/components/SidePanels/OutlinerPanel/OutlinerPanel.tsx
@@ -11,6 +11,10 @@ interface OutlinerPanelProps extends PanelProps {
   regions: any;
 }
 
+interface OutlinerTreeComponentProps {
+  regions: any;
+}
+
 const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) => {
   const [group, setGroup] = useState();
   const onOrderingChange = useCallback((value) => {
@@ -25,10 +29,6 @@ const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) =
   const onFilterChange = useCallback((value) => {
     regions.setFilteredRegions(value);
   }, [regions]);
-
-  const hiddenRegions = useMemo(() => {
-    return regions?.regions?.length - regions?.filter?.length;
-  }, [regions?.regions?.length, regions?.filter?.length]);
 
   useEffect(() => {
     setGroup(regions.group);
@@ -47,7 +47,52 @@ const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) =
         onGroupingChange={onGroupingChange}
         onFilterChange={onFilterChange}
       />
-      {(regions?.regions?.length > 0 && regions?.filter?.length === 0) ? (
+      <OutlinerTreeComponent regions={regions} />
+    </PanelBase>
+  );
+};
+
+const OutlinerStandAlone: FC<OutlinerPanelProps> = ({ regions }) => {
+  const onOrderingChange = useCallback((value) => {
+    regions.setSort(value);
+  }, [regions]);
+
+  const onGroupingChange = useCallback((value) => {
+    regions.setGrouping(value);
+  }, [regions]);
+
+  const onFilterChange = useCallback((value) => {
+    regions.setFilteredRegions(value);
+  }, [regions]);
+
+  return (
+    <Block name="outliner">
+      <ViewControls
+        grouping={regions.group}
+        ordering={regions.sort}
+        regions={regions}
+        orderingDirection={regions.sortOrder}
+        onOrderingChange={onOrderingChange}
+        onGroupingChange={onGroupingChange}
+        onFilterChange={onFilterChange}
+      />
+      <OutlinerTreeComponent regions={regions} />
+    </Block>
+  );
+};
+
+const OutlinerTreeComponent: FC<OutlinerTreeComponentProps> = observer(({ regions }) => {
+  const allRegionsHidden = regions?.regions?.length > 0 && regions?.filter?.length === 0;
+
+  const hiddenRegions = useMemo(() => {
+    if (!regions?.regions?.length || !regions.filter?.length) return 0;
+
+    return regions?.regions?.length - regions?.filter?.length;
+  }, [regions?.regions?.length, regions?.filter?.length]);
+
+  return(
+    <>
+      {allRegionsHidden ? (
         <Elem name="filters-empty">
           <IconInfo width={21} height={20} />
           <Elem name="filters-title">All regions hidden</Elem>
@@ -72,66 +117,9 @@ const OutlinerPanelComponent: FC<OutlinerPanelProps> = ({ regions, ...props }) =
             Regions not added
         </Elem>
       )}
-    </PanelBase>
+    </>
   );
-};
-
-const OutlinerStandAlone: FC<OutlinerPanelProps> = ({ regions }) => {
-  const onOrderingChange = useCallback((value) => {
-    regions.setSort(value);
-  }, [regions]);
-
-  const onGroupingChange = useCallback((value) => {
-    regions.setGrouping(value);
-  }, [regions]);
-
-  const onFilterChange = useCallback((value) => {
-    regions.setFilteredRegions(value);
-  }, [regions]);
-
-  const hiddenRegions = useMemo(() => {
-    return regions?.regions?.length - regions?.filter?.length;
-  }, [regions?.regions?.length, regions?.filter?.length]);
-
-  return (
-    <Block name="outliner">
-      <ViewControls
-        grouping={regions.group}
-        ordering={regions.sort}
-        regions={regions}
-        orderingDirection={regions.sortOrder}
-        onOrderingChange={onOrderingChange}
-        onGroupingChange={onGroupingChange}
-        onFilterChange={onFilterChange}
-      />
-      {(regions?.regions?.length > 0 && regions?.filter?.length === 0) ? (
-        <Elem name="filters-empty">
-          <IconInfo width={21} height={20} />
-          <Elem name="filters-title">All regions hidden</Elem>
-          <Elem name="filters-description">Adjust or remove the filters to view</Elem>
-        </Elem>
-      ) : regions?.regions?.length > 0 ? (
-        <>
-          <OutlinerTree
-            regions={regions}
-            selectedKeys={regions.selection.keys}
-          />
-          {hiddenRegions > 0 && (
-            <Elem name="filters-empty">
-              <IconInfo width={21} height={20} />
-              <Elem name="filters-title">There {hiddenRegions === 1 ? 'is' : 'are'} {hiddenRegions} hidden region{hiddenRegions > 1 && 's'}</Elem>
-              <Elem name="filters-description">Adjust or remove filters to view</Elem>
-            </Elem>
-          )}
-        </>
-      ) : (
-        <Elem name="empty">
-          Regions not added
-        </Elem>
-      )}
-    </Block>
-  );
-};
+});
 
 export const OutlinerComponent = observer(OutlinerStandAlone);
 

--- a/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -10,6 +10,7 @@ import { SidePanelsContext } from '../SidePanelsContext';
 import './ViewControls.styl';
 import { Filter } from '../../Filter/Filter';
 import { FF_DEV_3873, FF_LSDV_3025, isFF } from '../../../utils/feature-flags';
+import { observer } from 'mobx-react';
 
 const { Block, Elem } = BemWithSpecifiContext();
 
@@ -29,7 +30,7 @@ interface ViewControlsProps {
   onFilterChange: (filter: any) => void;
 }
 
-export const ViewControls: FC<ViewControlsProps> = ({
+export const ViewControls: FC<ViewControlsProps> = observer(({
   grouping,
   ordering,
   regions,
@@ -128,7 +129,7 @@ export const ViewControls: FC<ViewControlsProps> = ({
       )}
     </Block>
   );
-};
+});
 
 interface LabelInfo {
   label: string;

--- a/src/components/TopBar/Controls.js
+++ b/src/components/TopBar/Controls.js
@@ -47,7 +47,7 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
 
     if (isInProgress) return;
     setIsInProgress(true);
-    if(!inputRef.current || addedCommentThisSession){
+    if(addedCommentThisSession){
       callback();
     } else if((currentComment ?? '').trim()) {
       e.preventDefault();

--- a/src/components/TopBar/Controls.js
+++ b/src/components/TopBar/Controls.js
@@ -47,7 +47,7 @@ export const Controls = controlsInjector(observer(({ store, history, annotation 
 
     if (isInProgress) return;
     setIsInProgress(true);
-    if(addedCommentThisSession){
+    if(!inputRef.current || addedCommentThisSession){
       callback();
     } else if((currentComment ?? '').trim()) {
       e.preventDefault();

--- a/tests/functional/specs/outliner/filter.cy.ts
+++ b/tests/functional/specs/outliner/filter.cy.ts
@@ -88,11 +88,109 @@ const task = {
 };
 
 describe('Filter outliner scenario', () => {
+  const FF_LSDV_3025 = 'fflag_feat_front_lsdv_3025_outliner_filter_short';
+
   it('Check if filter is visible', () => {
     //the test will be created here
     LabelStudio.init({
       config,
       task,
     });
+
+    LabelStudio.setFeatureFlagsOnPageLoad({
+      [FF_LSDV_3025]: true,
+    });
+
+    cy.get('[data-cy="filter-button"]').should('be.visible');
+  });
+
+  it('Check if filter is filtering', () => {
+    //the test will be created here
+    LabelStudio.init({
+      config,
+      task,
+    });
+
+    LabelStudio.setFeatureFlagsOnPageLoad({
+      [FF_LSDV_3025]: true,
+    });
+
+    cy.get('[data-cy="filter-button"]').click();
+    cy.contains('Add Filter').click();
+    cy.get('[data-testid="operation-dropdown"]').click();
+    cy.contains('contains').click();
+    cy.get('[data-testid="filter-input"]').type('Planet');
+    Sidebar.hasRegions(1);
+  });
+
+  it('Check if filter message is hidden', () => {
+    //the test will be created here
+    LabelStudio.init({
+      config,
+      task,
+    });
+
+    LabelStudio.setFeatureFlagsOnPageLoad({
+      [FF_LSDV_3025]: true,
+    });
+
+    cy.contains('Adjust or remove filters to view').should('not.exist');
+  });
+
+  it('Check if filter message for 1 filter item is being shown', () => {
+    //the test will be created here
+    LabelStudio.init({
+      config,
+      task,
+    });
+
+    LabelStudio.setFeatureFlagsOnPageLoad({
+      [FF_LSDV_3025]: true,
+    });
+
+    cy.get('[data-cy="filter-button"]').click();
+    cy.contains('Add Filter').click();
+    cy.get('[data-testid="operation-dropdown"]').click();
+    cy.contains('contains').click();
+    cy.get('[data-testid="filter-input"]').type('Moonwalker');
+    cy.contains('There is 1 hidden region').should('be.visible');
+  });
+
+  it('Check if filter message for 2 or more filter items is being shown', () => {
+    //the test will be created here
+    LabelStudio.init({
+      config,
+      task,
+    });
+
+    LabelStudio.setFeatureFlagsOnPageLoad({
+      [FF_LSDV_3025]: true,
+    });
+
+    cy.get('[data-cy="filter-button"]').click();
+    cy.contains('Add Filter').click();
+    cy.get('[data-testid="operation-dropdown"]').click();
+    cy.contains('contains').click();
+    cy.get('[data-testid="filter-input"]').type('Moonwalker ');
+    cy.contains('There are 2 hidden regions').should('be.visible');
+  });
+
+  it('Check if filter message for all items hidden is being shown', () => {
+    //the test will be created here
+    LabelStudio.init({
+      config,
+      task,
+    });
+
+    LabelStudio.setFeatureFlagsOnPageLoad({
+      [FF_LSDV_3025]: true,
+    });
+
+    cy.get('[data-cy="filter-button"]').click();
+    cy.contains('Add Filter').click();
+    cy.get('[data-testid="operation-dropdown"]').click();
+    cy.contains('contains').click();
+    cy.get('[data-testid="filter-input"]').type('Moonwalker 4');
+    cy.contains('All regions hidden').should('be.visible');
   });
 });

--- a/tests/functional/specs/outliner/filter.cy.ts
+++ b/tests/functional/specs/outliner/filter.cy.ts
@@ -137,7 +137,7 @@ describe('Filter outliner scenario', () => {
     cy.contains('Adjust or remove filters to view').should('not.exist');
   });
 
-  it('Check if filter message for 1 filter item is being shown', () => {
+  it('Check if filter message for 1 filter item is showing', () => {
     //the test will be created here
     LabelStudio.init({
       config,
@@ -156,7 +156,7 @@ describe('Filter outliner scenario', () => {
     cy.contains('There is 1 hidden region').should('be.visible');
   });
 
-  it('Check if filter message for 2 or more filter items is being shown', () => {
+  it('Check if filter message for 2 or more filter items is showing', () => {
     //the test will be created here
     LabelStudio.init({
       config,
@@ -175,7 +175,7 @@ describe('Filter outliner scenario', () => {
     cy.contains('There are 2 hidden regions').should('be.visible');
   });
 
-  it('Check if filter message for all items hidden is being shown', () => {
+  it('Check if filter message for all items hidden is showing', () => {
     //the test will be created here
     LabelStudio.init({
       config,

--- a/tests/functional/specs/outliner/filter.cy.ts
+++ b/tests/functional/specs/outliner/filter.cy.ts
@@ -91,7 +91,6 @@ describe('Filter outliner scenario', () => {
   const FF_LSDV_3025 = 'fflag_feat_front_lsdv_3025_outliner_filter_short';
 
   it('Check if filter is visible', () => {
-    //the test will be created here
     LabelStudio.init({
       config,
       task,
@@ -105,7 +104,6 @@ describe('Filter outliner scenario', () => {
   });
 
   it('Check if filter is filtering', () => {
-    //the test will be created here
     LabelStudio.init({
       config,
       task,
@@ -124,7 +122,6 @@ describe('Filter outliner scenario', () => {
   });
 
   it('Check if filter message is hidden', () => {
-    //the test will be created here
     LabelStudio.init({
       config,
       task,
@@ -138,7 +135,6 @@ describe('Filter outliner scenario', () => {
   });
 
   it('Check if filter message for 1 filter item is showing', () => {
-    //the test will be created here
     LabelStudio.init({
       config,
       task,
@@ -157,7 +153,6 @@ describe('Filter outliner scenario', () => {
   });
 
   it('Check if filter message for 2 or more filter items is showing', () => {
-    //the test will be created here
     LabelStudio.init({
       config,
       task,
@@ -176,7 +171,6 @@ describe('Filter outliner scenario', () => {
   });
 
   it('Check if filter message for all items hidden is showing', () => {
-    //the test will be created here
     LabelStudio.init({
       config,
       task,


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The message that show how many itens are hidden was being shown even when there were no items hidden



#### What does this fix?
Now the message is being shown just when there are some items hidden.



#### Does this change affect security?
no



#### What alternative approaches were there?
na



#### What feature flags were used to cover this change?
fflag_feat_front_lsdv_3025_outliner_filter_short



### Does this PR introduce a breaking change?
_(check only one)_
- [x] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [x] integration
- [ ] unit

