### PR TITLE
fix: LSDV-5116: Change ground truth color to dark

### DIFF
--- a/src/components/CurrentEntity/GroundTruth.js
+++ b/src/components/CurrentEntity/GroundTruth.js
@@ -29,7 +29,7 @@ export const GroundTruth = observer(({ entity, disabled = false, size = 'md' }) 
           <Elem
             name="indicator"
             tag={isFF(FF_DEV_3873) && !entity.ground_truth ? LsStarOutline : LsStar}
-            mod={{ active: entity.ground_truth }}
+            mod={{ active: entity.ground_truth, dark: isFF(FF_DEV_3873) }}
           />
         </Elem>
       </Tooltip>

--- a/src/components/CurrentEntity/GroundTruth.styl
+++ b/src/components/CurrentEntity/GroundTruth.styl
@@ -13,6 +13,9 @@
   &__indicator
     color rgba(#000, 0.4)
 
+    &_dark
+      color #000
+
     &_active
       color #ffbb1a
 


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The icon of the Set as ground truth button is gray when it is enabled, which makes it look disabled.



#### What does this fix?
The icon is set to dark to seems to be enabled



#### What libraries were added/updated?
NA



#### Does this change affect performance?
no



#### Does this change affect security?
no



#### What alternative approaches were there?
NA



#### What feature flags were used to cover this change?
NA



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit

