### PR TITLE
fix: LSDV-5131: Fix broken styles for controls

### DIFF
--- a/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
+++ b/src/components/SidePanels/OutlinerPanel/ViewControls.tsx
@@ -189,10 +189,12 @@ const Grouping = <T extends string>({
     );
   }, [value, optionsList, readableValue, direction]);
 
+  // mods are already set in the button from type, so use it only in new UI
+  const extraStyles = isFF(FF_DEV_3873) ? { mod: { newUI: true } } : undefined;
 
   return (
     <Dropdown.Trigger content={dropdownContent} style={{ width: 200 }}>
-      <Button type="text" mod={{ newUI: isFF(FF_DEV_3873) }} icon={readableValue.icon} style={{
+      <Button type="text" {...extraStyles} icon={readableValue.icon} style={{
         padding: isFF(FF_DEV_3873) ? '0 6px 0 2px': 0,
         whiteSpace: 'nowrap',
       }} extra={(


### PR DESCRIPTION
`mod` is used inside Button and overrides everything if set directly. So for new UI this way is ok for now, but old code should not have it at all.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
UI regression because of Button+BEM combination caused `mod` to be overwritten by empty set, resetting button's styles.



#### What does this fix?
Set `mod` only if new UI enabled, otherwise do nothing at all.



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
_(for bug fixes/features, be as precise as possible. ex. Authentication, Annotation History, Review Stream etc.)_
