### PR TITLE
fix: Fix the problem with combineCoverage and coverageReport tasks in cypress tests

### DIFF
--- a/tests/functional/package.json
+++ b/tests/functional/package.json
@@ -25,5 +25,8 @@
     "typescript": "^5.0.2",
     "webpack": "^5.77.0",
     "webpack-cli": "^5.0.1"
+  },
+  "resolutions": {
+    "@cypress/code-coverage/istanbul-lib-coverage": "^3.2.0"
   }
 }


### PR DESCRIPTION
There is a problem with stale libraries in internal dependencies of cypress wich causes tests failures in some cases. Forcing of usage of more fresh version should solve this problem.