### PR TITLE
fix: LSDV-5136: Navigate between tabs in the side panels is not reseting the comments

### DIFF
--- a/src/components/Comments/CommentForm.tsx
+++ b/src/components/Comments/CommentForm.tsx
@@ -55,7 +55,6 @@ export const CommentForm: FC<CommentFormProps> = observer(({
 
 
   useEffect(() => {
-    commentStore.setAddedCommentThisSession(false);
     clearTooltipMessage();
   }, []);
 

--- a/src/components/TopBar/CurrentTask.js
+++ b/src/components/TopBar/CurrentTask.js
@@ -14,6 +14,8 @@ export const CurrentTask = observer(({ store }) => {
   const [visibleComments, setVisibleComments] = useState(0);
 
   useEffect(() => {
+    store.commentStore.setAddedCommentThisSession(false);
+
     const reactionDisposer = reaction(
       () => store.commentStore.comments.map(item => item.isDeleted),
       result => {


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
The postpone button was disabling when user switches between the tabs in side panels



#### What does this fix?
Change the way the comment in this session is checked



#### What is the new behavior?
_(if this is a breaking or feature change)_



#### What is the current behavior?
_(if this is a breaking or feature change)_



#### What libraries were added/updated?
_(list all with version changes)_



#### Does this change affect performance?
_(if so describe the impacts positive or negative)_



#### Does this change affect security?
_(if so describe the impacts positive or negative)_



#### What alternative approaches were there?
_(briefly list any if applicable)_



#### What feature flags were used to cover this change?
_(briefly list any if applicable)_



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit

