### PR TITLE
fix: LSDV-5162: Fix shifting of annotation tabs on hover

### DIFF
--- a/e2e/tests/regression-tests/annotation-button.test.js
+++ b/e2e/tests/regression-tests/annotation-button.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+Feature('Annotation button').tag('@regres');
+
+Scenario('Annotation button should keep border width on hover', async ({ I, LabelStudio }) => {
+  LabelStudio.setFeatureFlags({
+    fflag_feat_front_dev_3873_labeling_ui_improvements_short: true,
+  });
+
+  I.amOnPage('/');
+  LabelStudio.init({
+    config: `<View>
+  <Text name="text" value="$text" />
+</View>`,
+    data: {
+      text: 'Some text',
+    },
+    annotations: [
+      {
+        id: 'test_1',
+        result: [],
+      },
+      {
+        id: 'test_2',
+        result: [],
+      },
+    ],
+  });
+
+  const borderWidth = await I.executeScript(()=>{
+    const el = document.querySelector('.lsf-annotation-button:nth-child(2)');
+    const borderWidth = window.getComputedStyle(el).getPropertyValue('border-width');
+
+    return borderWidth;
+  });
+
+  I.moveCursorTo('.lsf-annotation-button:nth-child(2)');
+
+  const borderWidthHovered = await I.executeScript(()=>{
+    const el = document.querySelector('.lsf-annotation-button:nth-child(2)');
+    const borderWidth = window.getComputedStyle(el).getPropertyValue('border-width');
+
+    return borderWidth;
+  });
+
+  assert.strictEqual(
+    borderWidth,
+    borderWidthHovered,
+    'Annotation button\'s border width should not change on hover',
+  );
+});

--- a/src/components/AnnotationsCarousel/AnnotationButton.styl
+++ b/src/components/AnnotationsCarousel/AnnotationButton.styl
@@ -48,7 +48,7 @@
 
   &:hover
     background-color rgba(9, 109, 217, 0.12)
-    border 1px solid rgba(9, 109, 217, 0.16)
+    border-color rgba(9, 109, 217, 0.16)
     border-bottom-color transparent
     .annotation-button__ellipsisIcon
       visibility visible


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [x] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



### Describe the reason for change
Annotation tabs shift when hovered

#### What does this fix?
It fixes border width of hovered annotation tab.



#### What feature flags were used to cover this change?
`fflag_feat_front_dev_3873_labeling_ui_improvements_short`

### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)

### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [x] integration
- [ ] unit



### Which logical domain(s) does this change affect?
`AnnotationButton`