### PR TITLE
fix: LSDV-5148: Runtime error when user tries to update/submit duplicated annotation while original is already deleted

### DIFF
--- a/src/components/AnnotationsCarousel/AnnotationButton.tsx
+++ b/src/components/AnnotationsCarousel/AnnotationButton.tsx
@@ -92,7 +92,7 @@ export const AnnotationButton = observer(({ entity, capabilities, annotationStor
           entity.list.deleteAnnotation(entity);
         },
       });
-    }, []);
+    }, [entity]);
     const isPrediction = entity.type === 'prediction';
     const isDraft = !isDefined(entity.pk);
     const showGroundTruth = capabilities.groundTruthEnabled && !isPrediction && !isDraft;

--- a/src/stores/Annotation/store.js
+++ b/src/stores/Annotation/store.js
@@ -146,6 +146,15 @@ const AnnotationStoreModel = types
       return p;
     }
 
+    function clearDeletedParents(annotation) {
+      if (!annotation?.pk) return;
+      self.annotations.forEach(anno => {
+        if (anno.parent_annotation && +anno.parent_annotation === +annotation.pk) {
+          anno.parent_annotation = null;
+        }
+      });
+    }
+
     function deleteAnnotation(annotation) {
       getEnv(self).events.invoke('deleteAnnotation', self.store, annotation);
 
@@ -153,6 +162,11 @@ const AnnotationStoreModel = types
      * MST destroy annotation
      */
       destroy(annotation);
+      
+      /**
+       * Clear any other parent_annotations connected to this annotation
+       */
+      self.clearDeletedParents(annotation);
 
       self.selected = null;
       /**
@@ -531,6 +545,7 @@ const AnnotationStoreModel = types
       _unselectAll,
 
       deleteAnnotation,
+      clearDeletedParents,
       resetAnnotations,
     };
   });


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change

When deleting an annotation, which was the source of a duplicate, any updates or submissions of this duplicate annotation would cause an error because the original was already deleted.



#### What does this fix?

Clear any parent annotations connected to the deleted annotation, to ensure the proper submission handling takes place and does not throw errors when updating or submitting this data.


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Annotation Duplication/Deletion/Submission
