### PR TITLE
fix: LSDV-5214: Multi-word labels containing spaces in regions list are broken down into multiple rows on every space character

### DIFF
--- a/src/components/SidePanels/OutlinerPanel/TreeView.styl
+++ b/src/components/SidePanels/OutlinerPanel/TreeView.styl
@@ -55,7 +55,6 @@
     width min-content
     align-items center
     justify-content center
-    align-self: flex-start;
     color var(--icon-color)
 
     svg

--- a/src/components/SidePanels/OutlinerPanel/TreeView.styl
+++ b/src/components/SidePanels/OutlinerPanel/TreeView.styl
@@ -134,7 +134,6 @@
 
     &_newUI
       display flex
-      width 100%
       position initial
       justify-content space-between
 


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
_(link to issue, supportive screenshots etc.)_



#### What does this fix?
New UI RegionItem labels were getting pushed by the controls width taking up all the available space. These should be left to flex to distribute space and create this separation.


### Which logical domain(s) does this change affect?
RegionsPanel
