### PR TITLE
fix: LSDV-5158: Hide prediction delete button as it doesn't actually allow prediction deletions at this time

### DIFF
--- a/src/components/AnnotationsCarousel/AnnotationButton.tsx
+++ b/src/components/AnnotationsCarousel/AnnotationButton.tsx
@@ -133,7 +133,7 @@ export const AnnotationButton = observer(({ entity, capabilities, annotationStor
             Duplicate Annotation
           </Elem>
         )}
-        {capabilities.enableAnnotationDelete && (
+        {capabilities.enableAnnotationDelete && !isPrediction && (
           <>
             <Elem name="seperator"></Elem>
             <Elem name="option" mod={{ delete: true }} onClick={deleteAnnotation}>


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
Currently predictions cannot be deleted, so there is no point in having a delete button. Removing this for consistency until such time that we have a proper method of deleting predictions.



### Which logical domain(s) does this change affect?
AnnotationButton
