### PR TITLE
fix: LSDV-5235: Use alternate check for postpone based on presence of interfaces instead of FF

### DIFF
--- a/src/components/TopBar/CurrentTask.js
+++ b/src/components/TopBar/CurrentTask.js
@@ -2,7 +2,7 @@ import { observer } from 'mobx-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Button } from '../../common/Button/Button';
 import { Block, Elem } from '../../utils/bem';
-import { FF_DEV_3034, FF_DEV_3873, FF_DEV_4174, isFF } from '../../utils/feature-flags';
+import { FF_DEV_3873, FF_DEV_4174, isFF } from '../../utils/feature-flags';
 import { guidGenerator } from '../../utils/unique';
 import { isDefined } from '../../utils/utilities';
 import './CurrentTask.styl';
@@ -42,24 +42,23 @@ export const CurrentTask = observer(({ store }) => {
   const showCounter = store.hasInterface('topbar:task-counter');
 
   // @todo some interface?
-  let canPostpone = isFF(FF_DEV_3034)
-    && !isDefined(store.annotationStore.selected.pk)
+  let canPostpone = !isDefined(store.annotationStore.selected.pk)
     && !store.canGoNextTask
     && !store.hasInterface('review')
     && store.hasInterface('postpone');
 
 
-  if (isFF(FF_DEV_4174)) {
+  if (store.hasInterface('annotations:comments') && isFF(FF_DEV_4174)) {
     canPostpone = canPostpone && store.commentStore.addedCommentThisSession && (visibleComments >= initialCommentLength);
   }
 
   return (
     <Elem name="section">
       <Block name="current-task" mod={{ 'with-history': historyEnabled }} style={{
-        padding:isFF(FF_DEV_3873) && 0,
-        width:isFF(FF_DEV_3873) && 'auto',
+        padding: isFF(FF_DEV_3873) && 0,
+        width: isFF(FF_DEV_3873) && 'auto',
       }}>
-        <Elem name="task-id" style={{ fontSize:isFF(FF_DEV_3873) ? 12 : 14 }}>
+        <Elem name="task-id" style={{ fontSize: isFF(FF_DEV_3873) ? 12 : 14 }}>
           {store.task.id ?? guidGenerator()}
           {historyEnabled && showCounter && (
             <Elem name="task-count">


### PR DESCRIPTION
A follow up to this #1433, which includes a missing fix for the TopBar.