### PR TITLE
fix: LSDV-5262: Save draft on postpone

### DIFF
--- a/src/stores/Annotation/Annotation.js
+++ b/src/stores/Annotation/Annotation.js
@@ -664,7 +664,7 @@ export const Annotation = types
       onSnapshot(self.areas, self.autosave);
     }),
 
-    saveDraft() {
+    saveDraft(params) {
       // if this is now a history item or prediction don't save it
       if (!self.editable) return;
 
@@ -677,7 +677,7 @@ export const Annotation = types
       self.versions.draft = result;
       self.setDraftSaving(true);
 
-      self.store.submitDraft(self).then(self.onDraftSaved);
+      return self.store.submitDraft(self, params).then(self.onDraftSaved);
     },
 
     saveDraftImmediately() {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -724,12 +724,9 @@ export default types
     async function postponeTask() {
       const annotation = self.annotationStore.selected;
 
-      if (!annotation.versions.draft) {
-        // annotation created from prediction, so no draft was created
-        annotation.versions.draft = annotation.versions.result;
-      }
-
-      await self.submitDraft(annotation, { was_postponed: true });
+      // save draft before postponing; this can be new draft with FF_DEV_4174 off
+      // or annotation created from prediction
+      await annotation.saveDraft({ was_postponed: true });
       await getEnv(self).events.invoke('nextTask');
     }
 


### PR DESCRIPTION
Draft is not saved on postpone, only prediction is drafted if it was the source for annotation. Fixed.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Frontend



### Describe the reason for change
Draft is not saved on postpone, only prediction is drafted if it was the source for annotation.



#### What does this fix?
Save draft on postpone and wait for it.



#### What is the new behavior?
Save draft on postpone and wait for it.



#### What is the current behavior?
Postpone just saves result as draft, but that's only the case when annotation was created from prediction, in all other cases latest changes are lost.



#### What libraries were added/updated?
none



#### Does this change affect performance?
Postpone will wait for draft saving, so this can add some time, but draft is saved in "fast" way.



#### Does this change affect security?
nope



#### What alternative approaches were there?
Draft should be saved anyway, so this could just be different from technical perspective. We could call `autosave.flush()`, but this will not save draft if drafts are paused, which is not good I think.



#### What feature flags were used to cover this change?
`fflag_fix_back_dev_4174_overlap_issue_experiments_10012023_short` — if it's on, postpone works only when comment is left, but even in this case this fix fixes a problem with lost data.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [x] Not sure — draft is saved differently now, but it should not loose any data, quite the opposite — it saves all of them; comments will create draft if it was not created yet, and will be attached to it, so won't be lost as well.



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Postpone, Drafts
