### PR TITLE
fix: LSDV-5260: Selected region can not be moved / resized when it's under another region

### DIFF
--- a/e2e/tests/audio/audio-regions.test.js
+++ b/e2e/tests/audio/audio-regions.test.js
@@ -210,7 +210,12 @@ Scenario('Selecting a region brings it to the front of the stack', async functio
   AtSidebar.clickRegion('Speech');
   AtSidebar.seeSelectedRegion('Speech');
 
-  // click on the overlapping region to show that it is now the top in the list
+  // click on the overlapping region will deselect it, which shows that it is now the top in the list
+  AtAudioView.clickAt(50);
+  AtSidebar.dontSeeSelectedRegion('Speech');
+  AtSidebar.dontSeeSelectedRegion('Noise');
+
+  // click on the overlapping region will select the top item of the list, which will now be the item which was brought to the front by the original interaction.
   AtAudioView.clickAt(50);
   AtSidebar.seeSelectedRegion('Speech');
 });

--- a/e2e/tests/audio/audio-regions.test.js
+++ b/e2e/tests/audio/audio-regions.test.js
@@ -177,6 +177,44 @@ Scenario('Can select a region below a hidden region', async function({ I, LabelS
   AtSidebar.seeSelectedRegion('Speech');
 });
 
+Scenario('Selecting a region brings it to the front of the stack', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
+  LabelStudio.setFeatureFlags({
+    ff_front_dev_2715_audio_3_280722_short: true,
+  });
+  I.amOnPage('/');
+
+  LabelStudio.init(paramsSpeech);
+
+  await AtAudioView.waitForAudio();
+  await AtAudioView.lookForStage();
+
+  // create a new region
+  I.pressKey('1');
+  AtAudioView.dragAudioElement(50, 80);
+  I.pressKey('u');
+
+  AtSidebar.seeRegions(1);
+
+  // create a new region above the first one
+  I.pressKey('2');
+  AtAudioView.dragAudioElement(49, 81);
+  I.pressKey('u');
+
+  AtSidebar.seeRegions(2);
+
+  // click on the top-most region visible to select it
+  AtAudioView.clickAt(50);
+  AtSidebar.seeSelectedRegion('Noise');
+
+  // Select the bottom most region to bring it to the top
+  AtSidebar.clickRegion('Speech');
+  AtSidebar.seeSelectedRegion('Speech');
+
+  // click on the overlapping region to show that it is now the top in the list
+  AtAudioView.clickAt(50);
+  AtSidebar.seeSelectedRegion('Speech');
+});
+
 Scenario('Delete region by pressing delete hotkey', async function({ I, LabelStudio, AtAudioView, AtSidebar }) {
   LabelStudio.setFeatureFlags({
     ff_front_dev_2715_audio_3_280722_short: true,

--- a/src/lib/AudioUltra/Regions/Regions.ts
+++ b/src/lib/AudioUltra/Regions/Regions.ts
@@ -1,5 +1,13 @@
 import { rgba, RgbaColorArray } from '../Common/Color';
-import { clamp, defaults, findLast, getCursorPositionX, getCursorPositionY, isInRange, pixelsToTime } from '../Common/Utils';
+import {
+  clamp,
+  defaults,
+  findLast,
+  getCursorPositionX,
+  getCursorPositionY,
+  isInRange,
+  pixelsToTime
+} from '../Common/Utils';
 import { CursorSymbol } from '../Cursor/Cursor';
 import { LayerGroup } from '../Visual/LayerGroup';
 import { Visualizer } from '../Visual/Visualizer';
@@ -185,6 +193,12 @@ export class Regions {
     if (render) {
       this.redraw();
     }
+  }
+
+  bringRegionToFront(regionId: string) {
+    const originalIndex = this.regions.findIndex(reg => reg.id === regionId);
+
+    this.regions.push(...this.regions.splice(originalIndex, 1));
   }
 
   destroy() {
@@ -379,7 +393,6 @@ export class Regions {
     if (this.layerGroup.isVisible && region?.updateable) {
       e.preventDefault();
       e.stopPropagation();
-
       region.invoke('mouseDown', [region, e]);
     }
   };
@@ -398,7 +411,7 @@ export class Regions {
 
     if (e.target && mainLayer?.canvas?.contains(e.target)) {
       const region = this.findRegionUnderCursor(e);
-  
+
       if (this.layerGroup.isVisible && region) {
         region.invoke('click', [region, e]);
       }

--- a/src/lib/AudioUltra/Regions/Segment.ts
+++ b/src/lib/AudioUltra/Regions/Segment.ts
@@ -124,6 +124,13 @@ export class Segment extends Events<SegmentEvents> {
     this.waveform.invoke('regionUpdated', [this]);
   }
 
+  /**
+   * Move this segment to the front so it is readily available to the user to manipulate
+   */
+  bringToFront() {
+    this.controller.bringRegionToFront(this.id);
+  }
+
   protected get layerName() {
     return `region-${this.id}`;
   }
@@ -279,6 +286,7 @@ export class Segment extends Events<SegmentEvents> {
     const x = getCursorPositionX(e, container) + scrollLeft;
     const { start, end } = this;
 
+    this.bringToFront();
     this.draggingStartPosition = { grabPosition: x, start, end };
     this.isGrabbingEdge = this.edgeGrabCheck(e);
     document.addEventListener('mouseup', this.handleMouseUp);

--- a/src/regions/AudioRegion/AudioUltraRegionModel.js
+++ b/src/regions/AudioRegion/AudioUltraRegionModel.js
@@ -75,6 +75,7 @@ export const AudioUltraRegionModel = types
       selectRegion() {
         if (!self._ws_region) return;
         self._ws_region.handleSelected(true);
+        self._ws_region.bringToFront();
         self._ws_region.scrollToRegion();
       },
 
@@ -131,7 +132,7 @@ export const AudioUltraRegionModel = types
 
       setProperty(propName, value) {
         Super.setProperty(propName, value);
-        if ( ['start', 'end'].includes(propName) ) {
+        if (['start', 'end'].includes(propName)) {
           self.updatePosition();
         }
       },


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
When interacting with the Audio regions, it was only considering the layered indices in order of when the region was created. This leads to lack of context and ability to freely work with overlapping regions efficiently.



#### What does this fix?
Anytime a region is selected from within the audio interface or the regions sidepanel, bring the region to front of the list so that it can be easily dragged or resized without having to hide overlapping regions or move out the obscured region.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [X] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Audio
