### PR TITLE
fix: LSDV-5259: Duplication of annotations can only happen if creation is allowed.

### DIFF
--- a/src/components/AnnotationsCarousel/AnnotationButton.tsx
+++ b/src/components/AnnotationsCarousel/AnnotationButton.tsx
@@ -108,6 +108,7 @@ export const AnnotationButton = observer(({ entity, capabilities, annotationStor
     const isPrediction = entity.type === 'prediction';
     const isDraft = !isDefined(entity.pk);
     const showGroundTruth = capabilities.groundTruthEnabled && !isPrediction && !isDraft;
+    const showDuplicateAnnotation = capabilities.enableCreateAnnotation && !isDraft;
 
     return (
       <Block name="AnnotationButtonContextMenu">
@@ -125,7 +126,7 @@ export const AnnotationButton = observer(({ entity, capabilities, annotationStor
             as Ground Truth
           </Elem>
         )}
-        {!isDraft && (
+        {showDuplicateAnnotation && (
           <Elem name="option" mod={{ duplicate: true }} onClick={duplicateAnnotation}>
             <Elem name="icon">
               <IconDuplicate width={20} height={24} />


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
Duplication of annotations should follow the same logic as creation, and only be available if the capability is set. This logic diverged a bit, which will cause bugs with upstream usages of LSF.



#### What does this fix?
Only show the duplication button for annotations, if the AnnotationTab has the capability to create a new annotation.



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [X] No
- [ ] Not sure (briefly explain the situation below)



### Which logical domain(s) does this change affect?
AnnotationTab
