### PR TITLE
fix: ImageView interaction skip behavior

### DIFF
--- a/src/components/ImageView/ImageView.js
+++ b/src/components/ImageView/ImageView.js
@@ -23,6 +23,7 @@ import { fixRectToFit } from '../../utils/image';
 import { FF_DEV_1285, FF_DEV_1442, FF_DEV_3077, FF_DEV_3793, FF_DEV_4081, FF_LSDV_4583_6, FF_LSDV_4711, isFF } from '../../utils/feature-flags';
 import { Pagination } from '../../common/Pagination/Pagination';
 import { Image } from './Image';
+import { INTERACTION_SKIPPERS } from '../../tags/object/Image/Image';
 
 Konva.showWarnings = false;
 
@@ -627,7 +628,7 @@ export default observer(
       }
 
       item.freezeHistory();
-      item.setSkipInteractions(false);
+      item.removeInteractionSkipper(INTERACTION_SKIPPERS.PAN);
 
       return item.event('mouseup', e, e.evt.offsetX, e.evt.offsetY);
     };
@@ -649,7 +650,7 @@ export default observer(
       }
 
       if ((isMouseWheelClick || isShiftDrag) && item.zoomScale > 1) {
-        item.setSkipInteractions(true);
+        item.addInteractionSkipper(INTERACTION_SKIPPERS.PAN);
         e.evt.preventDefault();
 
         const newPos = {

--- a/src/tools/Polygon.js
+++ b/src/tools/Polygon.js
@@ -85,6 +85,11 @@ const _Tool = types
     let closed;
 
     return {
+      shouldSkipInteractions() {
+        const activePolygon = self.getActivePolygon;
+
+        return activePolygon && !activePolygon.mouseOverStartPoint;
+      },
       handleToolSwitch(tool) {
         self.stopListening();
         if (self.getCurrentArea()?.isDrawing && tool.toolName !== 'ZoomPanTool') {


### PR DESCRIPTION
### PR fulfills these requirements
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [x] Frontend



#### What does this fix?
Bug was that drawing a polygon overlapping an existing one wasn't working properly. Even when pressing the 'ctrl' key to disable interactions, the existing polygon was getting selected/unselected at each click. This was because the 'skipInteraction' flag was set by the ctrl key, and then overwritten by the click (ImageView couldn't keep track if the interactions were to be skipped for multiple reasons at the same time).

With the fix, ImageView can keep track of multiple reasons for the interaction skip, therefore avoiding the flag to be overwritten.

In addition, I added the 'shouldSkipInteractions' in the polygon model to skip interactions when we already started drawing a new polygon (preventing the need to hold the 'ctrl' key the whole time when drawing overlapping polygons).





### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)
