### PR TITLE
fix: LSDV-5314: Persist collapse panel state

### DIFF
--- a/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
+++ b/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
@@ -13,6 +13,9 @@ import { Tabs } from './Tabs';
 import { CommonProps, DropSide, EventHandlers, JoinOrder, PanelBBox, Result, Side, SidePanelsProps, ViewportSize } from './types';
 import { findPanelViewByName, findZIndices, getAttachedPerSide, getLeftKeys, getRightKeys, getSnappedHeights, joinPanelColumns, newPanelInState, partialEmptyBaseProps, redistributeHeights, renameKeys, resizePanelColumns, restorePanel, savePanels, setActive, setActiveDefaults, splitPanelColumns, stateAddedTab, stateRemovedTab, stateRemovePanelEmptyViews } from './utils';
 
+
+
+
 const maxWindowWidth = 980;
 const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
   currentEntity,
@@ -21,6 +24,7 @@ const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
   showComments,
   focusTab,
 }) => {
+  
   const snapThreshold = 5;
   const regions = currentEntity.regionStore;
   const viewportSize = useRef<ViewportSize>({ width: 0, height: 0 });
@@ -30,10 +34,10 @@ const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
   const [lockPanelContents, setLockPanelContents] = useState(false);
   const [positioning, setPositioning] = useState(false);
   const [initialized, setInitialized] = useState(false);
-  const [collapsedSide, setCollapsedSide] = useState({ [Side.left]: false, [Side.right]: false });
   const rootRef = useRef<HTMLDivElement>();
   const [snap, setSnap] = useState<DropSide | Side | undefined>();
-  const [panelData, setPanelData] = useState<Record<string, PanelBBox>>(restorePanel(showComments));
+  const [panelData, setPanelData] = useState<Record<string, PanelBBox>>(restorePanel(showComments).panelData);
+  const [collapsedSide, setCollapsedSide] = useState(restorePanel(showComments).collapsedSide);
   const [breakPointActiveTab, setBreakPointActiveTab] = useState(0);
   const localSnap = useRef(snap);
   const collapsedSideRef = useRef(collapsedSide);
@@ -379,8 +383,8 @@ const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
   }, [panelData, commonProps, lockPanelContents, panelsHidden, panelBreakPoint, positioning, panelMaxWidth, collapsedSide, snap]);
 
   useEffect(() => {
-    if (Object.keys(panelData).length) savePanels(panelData);
-  }, [panelData]);
+    if (Object.keys(panelData).length) savePanels(panelData, collapsedSide);
+  }, [panelData, collapsedSide]);
 
   useEffect(() => {
     if (focusTab) {

--- a/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
+++ b/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
@@ -13,9 +13,6 @@ import { Tabs } from './Tabs';
 import { CommonProps, DropSide, EventHandlers, JoinOrder, PanelBBox, Result, Side, SidePanelsProps, ViewportSize } from './types';
 import { findPanelViewByName, findZIndices, getAttachedPerSide, getLeftKeys, getRightKeys, getSnappedHeights, joinPanelColumns, newPanelInState, partialEmptyBaseProps, redistributeHeights, renameKeys, resizePanelColumns, restorePanel, savePanels, setActive, setActiveDefaults, splitPanelColumns, stateAddedTab, stateRemovedTab, stateRemovePanelEmptyViews } from './utils';
 
-
-
-
 const maxWindowWidth = 980;
 const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
   currentEntity,

--- a/src/components/SidePanels/TabPanels/__tests__/utils.test.tsx
+++ b/src/components/SidePanels/TabPanels/__tests__/utils.test.tsx
@@ -714,7 +714,6 @@ describe('findPanelViewByName', () => {
   });
 });
 
-
 describe('checkCollapsedPanelsHaveData', () => {
   const collapsedSide = {
     left: true,

--- a/src/components/SidePanels/TabPanels/__tests__/utils.test.tsx
+++ b/src/components/SidePanels/TabPanels/__tests__/utils.test.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_PANEL_HEIGHT, DEFAULT_PANEL_WIDTH } from '../../constants';
 import { JoinOrder, PanelBBox, Side } from '../types';
-import { determineDroppableArea, determineLeftOrRight, findPanelViewByName, findZIndices, getSnappedHeights, joinPanelColumns, redistributeHeights, setActive, setActiveDefaults, splitPanelColumns, stateAddedTab, stateRemovedTab, stateRemovePanelEmptyViews } from '../utils';
+import { checkCollapsedPanelsHaveData, determineDroppableArea, determineLeftOrRight, findPanelViewByName, findZIndices, getSnappedHeights, joinPanelColumns, redistributeHeights, setActive, setActiveDefaults, splitPanelColumns, stateAddedTab, stateRemovedTab, stateRemovePanelEmptyViews } from '../utils';
 
 
 const dummyPanels: Record<string, PanelBBox> = {
@@ -711,5 +711,46 @@ describe('findPanelViewByName', () => {
     const result = findPanelViewByName(state, name);
 
     expect(result).toBeUndefined();
+  });
+});
+
+
+describe('checkCollapsedPanelsHaveData', () => {
+  const collapsedSide = {
+    left: true,
+    right: false,
+  };
+
+  const panelData = {
+    panel1: { alignment: 'left', detached: false },
+    panel2: { alignment: 'right', detached: false },
+    panel3: { alignment: 'top', detached: true },
+    panel4: { alignment: 'bottom', detached: false },
+  };
+
+  it('should update collapsedSide correctly when there is data in collapsed panels', () => {
+    const expected = {
+      left: true,
+      right: false,
+    };
+
+    const result = checkCollapsedPanelsHaveData(collapsedSide, panelData);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should not update collapsedSide when there is no data in collapsed panels', () => {
+    const collapsedSideWithNoData = {
+      left: true,
+      right: true,
+    };
+    const expected = { ...collapsedSideWithNoData };
+
+    const result = checkCollapsedPanelsHaveData(
+      collapsedSideWithNoData,
+      panelData,
+    );
+
+    expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
### PR fulfills these requirements
- [X] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [X] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [X] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [X] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [X] Frontend



### Describe the reason for change
Panels with tabs were not saving collapsed state 


#### What does this fix?
This saves the collapsed state of side panels 


#### What is the new behavior?
Now local-storage will consistently preserve collapsed state and repopulate into app state 


#### What is the current behavior?
side panels collapsed states are not saved


#### What libraries were added/updated?
N/A


#### Does this change affect performance?
no


#### Does this change affect security?
no


#### What alternative approaches were there?
we could have used a separate storage item but opted instead to lump with panel data so that we can check that the two match upon retrieval


#### What feature flags were used to cover this change?
n/a


### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [X] unit



### Which logical domain(s) does this change affect?
sidepanels 