### PR TITLE
fix: LSDV-5316: Fix Ctrl/Cmd+X in Config Editor 

### DIFF
--- a/src/hooks/useRegionsCopyPaste.ts
+++ b/src/hooks/useRegionsCopyPaste.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 export const useRegionsCopyPaste = (entity: any) => {
-  useEffect(()=>{
+  useEffect(() => {
     const isFocusable = (el: Node | Window | HTMLElement | null) => {
       if (!el) return false;
       if ((el as Node).nodeType !== Node.ELEMENT_NODE) return false;
@@ -40,8 +40,6 @@ export const useRegionsCopyPaste = (entity: any) => {
           return { ...res, readonly: false };
         });
 
-        console.log({ results });
-
         entity.appendResults(results);
         ev.preventDefault();
       } catch (e) {
@@ -50,19 +48,19 @@ export const useRegionsCopyPaste = (entity: any) => {
       }
     };
 
-    const copyHandler = (ev: Event) =>{
+    const copyHandler = (ev: Event) => {
       if (!allowCopyPaste()) return;
 
       copyToClipboard(ev as ClipboardEvent);
     };
 
-    const pasteHandler = (ev: Event) =>{
+    const pasteHandler = (ev: Event) => {
       if (!allowCopyPaste()) return;
 
       pasteFromClipboard(ev as ClipboardEvent);
     };
 
-    const cutHandler = (ev: Event) =>{
+    const cutHandler = (ev: Event) => {
       if (!allowCopyPaste()) return;
 
       copyToClipboard(ev as ClipboardEvent);

--- a/src/hooks/useRegionsCopyPaste.ts
+++ b/src/hooks/useRegionsCopyPaste.ts
@@ -63,9 +63,7 @@ export const useRegionsCopyPaste = (entity: any) => {
     };
 
     const cutHandler = (ev: Event) =>{
-      const selection = window.getSelection();
-
-      if (!selection?.isCollapsed) return;
+      if (!allowCopyPaste()) return;
 
       copyToClipboard(ev as ClipboardEvent);
       entity.deleteSelectedRegions();


### PR DESCRIPTION
Handle Cmd+X in the same way as Cmd+C and Cmd+V in regions copypasting code, so in Config Editor Cmd+X would not be overtaken by mistake.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [x] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [x] Product design
- [x] Frontend



### Describe the reason for change
Cmd+X does nothing in Config Editor



#### What does this fix?
Doesn't prevent Cmd+X from usual execution when it's in CodeMirror editor.



#### What libraries were added/updated?
none



#### Does this change affect performance?
nope



#### Does this change affect security?
nope



#### What alternative approaches were there?
it just makes it in sync with copy and paste handlers, so no alternatives



#### What feature flags were used to cover this change?
none



### Does this PR introduce a breaking change?
_(check only one)_
- [ ] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [x] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
Config Editor
