### PR TITLE
chore: CI test artifact handling improvement

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -1,0 +1,33 @@
+# source https://github.com/actions/upload-artifact/issues/199#issuecomment-1516555821
+name: Download artifact
+description: Wrapper around GitHub's official action, with additional extraction before download
+
+# https://github.com/actions/download-artifact/blob/main/action.yml
+inputs:
+  name:
+    description: Artifact name
+    required: true
+  path:
+    description: Destination path
+    required: false
+    default: .
+
+runs:
+  using: composite
+  steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+
+    - name: Extract artifacts
+      run: tar -xvf ${{ inputs.name }}.tar
+      shell: bash
+      working-directory: ${{ inputs.path }}
+
+    - name: Remove archive
+      run: rm -f ${{ inputs.name }}.tar
+      shell: bash
+      working-directory: ${{ inputs.path }}
+

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -1,0 +1,47 @@
+# source https://github.com/actions/upload-artifact/issues/199#issuecomment-1516555821
+name: Upload artifact
+description: Wrapper around GitHub's official action, with additional archiving before upload
+
+# https://github.com/actions/upload-artifact/blob/main/action.yml
+inputs:
+  name:
+    description: Artifact name
+    required: true
+  path:
+    description: A file, directory or wildcard pattern that describes what to upload
+    required: true
+  if-no-files-found:
+    description: >
+      The desired behavior if no files are found using the provided path.
+      Available Options:
+        warn: Output a warning but do not fail the action
+        error: Fail the action with an error message
+        ignore: Do not output any warnings or errors, the action does not fail
+    required: false
+    default: warn
+  retention-days:
+    description: >
+      Duration after which artifact will expire in days. 0 means using default retention.
+      Minimum 1 day.
+      Maximum 90 days unless changed from the repository settings page.
+    required: false
+    default: '0'
+
+runs:
+  using: composite
+  steps:
+    - name: Archive artifacts
+      run: tar -cvf ${{ inputs.name }}.tar ${{ inputs.path }}
+      shell: bash
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        name: ${{ inputs.name }}
+        path: ${{ inputs.name }}.tar
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: Remove archive
+      run: rm -f ${{ inputs.name }}.tar
+      shell: bash

--- a/.github/workflows/build_bundle.yml
+++ b/.github/workflows/build_bundle.yml
@@ -69,7 +69,7 @@ jobs:
 
       # upload this build as artifact to current Action
       - name: Upload bundle
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         with:
           name: LSF-${{ inputs.build_for_coverage && 'coverage-' || '' }}${{ inputs.sha }}
           path: build/

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -58,8 +58,6 @@ jobs:
         with:
           name: LSF-coverage-${{ inputs.sha }}
 
-          path: build/
-
       # run http-server with build in background (will be killed after job ends)
       # do this only for master branch (so only for push event)
       # because pr can contain unfinished job

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -54,7 +54,7 @@ jobs:
         run: du -d 0 -h ${{ steps.yarn-cache-dir-path.outputs.dir }}
 
       - name: "Download bundle"
-        uses: actions/download-artifact@v3
+        uses: ./.github/actions/download-artifact
         with:
           name: LSF-coverage-${{ inputs.sha }}
 
@@ -95,7 +95,7 @@ jobs:
           yarn run test:ci ${{ steps.cpu-info.outputs.cores-count }}
 
       - name: "Upload e2e output" 
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         if: ${{ failure() }}
         with:
           name: e2e output
@@ -108,7 +108,7 @@ jobs:
           yarn coverage:merge 
 
       - name: Upload coverage to Artifact
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         if: ${{ success() }}
         with:
           name: e2e-tests-coverage

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -98,7 +98,7 @@ jobs:
         uses: ./.github/actions/upload-artifact
         if: ${{ failure() }}
         with:
-          name: e2e output
+          name: e2e-output
           path: e2e/output/
 
       - name: Merge coverage reports

--- a/.github/workflows/fun_tests.yml
+++ b/.github/workflows/fun_tests.yml
@@ -109,14 +109,18 @@ jobs:
           cd ./tests/functional
           yarn run test:parallel
 
+      - name: Prepare suite output
+        if: ${{ failure() }}
+        run: |
+          cd ./tests/functional
+          rm -rf node_modules
+
       - name: "Upload suite output" 
         uses: ./.github/actions/upload-artifact
         if: ${{ failure() }}
         with:
           name: failure-result
-          path: |
-            ./tests/functional
-            !./tests/functional/node_modules
+          path: ./tests/functional
 
       - name: Prepare coverage report
         if: ${{ success() }}

--- a/.github/workflows/fun_tests.yml
+++ b/.github/workflows/fun_tests.yml
@@ -67,7 +67,7 @@ jobs:
         run: du -d 0 -h ${{ steps.yarn-cache-dir-path.outputs.dir }}
 
       - name: "Download bundle"
-        uses: actions/download-artifact@v3
+        uses: ./.github/actions/download-artifact
         with:
           name: LSF-coverage-${{ inputs.sha }}
           path: build/
@@ -111,7 +111,7 @@ jobs:
           yarn run test:parallel
 
       - name: "Upload suite output" 
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         if: ${{ failure() }}
         with:
           name: failure-result
@@ -125,7 +125,7 @@ jobs:
           yarn cvg:report
 
       - name: Upload coverage to Artifact
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         if: ${{ success() }}
         with:
           name: cypress-tests-coverage

--- a/.github/workflows/fun_tests.yml
+++ b/.github/workflows/fun_tests.yml
@@ -70,7 +70,6 @@ jobs:
         uses: ./.github/actions/download-artifact
         with:
           name: LSF-coverage-${{ inputs.sha }}
-          path: build/
 
       # run http-server with build in background (will be killed after job ends)
       # do this only for master branch (so only for push event)

--- a/.github/workflows/fun_tests.yml
+++ b/.github/workflows/fun_tests.yml
@@ -115,7 +115,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: failure-result
-          path: ./tests/functional
+          path: |
+            ./tests/functional
+            !./tests/functional/node_modules
 
       - name: Prepare coverage report
         if: ${{ success() }}

--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -23,7 +23,6 @@ jobs:
         uses: ./.github/actions/download-artifact
         with:
           name: unit-tests-coverage
-          path: coverage/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.4
@@ -46,7 +45,6 @@ jobs:
         uses: ./.github/actions/download-artifact
         with:
           name: e2e-tests-coverage
-          path: coverage/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.4
@@ -69,7 +67,6 @@ jobs:
         uses: ./.github/actions/download-artifact
         with:
           name: cypress-tests-coverage
-          path: coverage/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Download Unit coverage from Artifact"
-        uses: actions/download-artifact@v3
+        uses: ./.github/actions/download-artifact
         with:
           name: unit-tests-coverage
           path: coverage/
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Download E2E coverage from Artifact"
-        uses: actions/download-artifact@v3
+        uses: ./.github/actions/download-artifact
         with:
           name: e2e-tests-coverage
           path: coverage/
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Download Cypress coverage from Artifact"
-        uses: actions/download-artifact@v3
+        uses: ./.github/actions/download-artifact
         with:
           name: cypress-tests-coverage
           path: coverage/

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -58,7 +58,7 @@ jobs:
       #     token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage to Artifacts
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         with:
           name: unit-tests-coverage
           path: coverage/


### PR DESCRIPTION
There were cases that the handling of files through the general github actions upload/download artifact would create a massive overhead requiring to call the api for every single file individually. This along with some large file counts creating > 30 minute archive upload runs 🤯. This is a massive waste of resources and holds up pipeline times.

This changes the used github actions for upload/download archive to tar on upload and send a single file (much more efficient given the way the upload works with chunked + resumable uploads). Conversely all download-artifact calls untar the file in the same manner. The only difference here is that we no longer have to specify paths on the download as the directory structure is captured in the upload tar.