### PR TITLE
fix: LSDV-5400: Auto accept all annotations

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -15,7 +15,7 @@ import Settings from './SettingsStore';
 import Task from './TaskStore';
 import { UserExtended } from './UserStore';
 import { UserLabels } from './UserLabels';
-import { FF_DEV_1536, FF_DEV_2715, FF_LSDV_4998, isFF } from '../utils/feature-flags';
+import { FF_DEV_1536, FF_DEV_2715, FF_LLM_EPIC, FF_LSDV_4998, isFF } from '../utils/feature-flags';
 import { CommentStore } from './Comment/CommentStore';
 import { destroy as destroySharedStore } from '../mixins/SharedChoiceStore/mixin';
 
@@ -219,6 +219,7 @@ export default types
       return self.forceAutoAnnotation || self._autoAnnotation;
     },
     get autoAcceptSuggestions() {
+      if (isFF(FF_LLM_EPIC)) return true;
       return self.forceAutoAcceptSuggestions || self._autoAcceptSuggestions;
     },
   }))

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -171,6 +171,12 @@ export const FF_DEV_4174 = 'fflag_fix_back_dev_4174_overlap_issue_experiments_10
 export const FF_LSDV_E_278 = 'fflag_feat_front_lsdv_e_278_contextual_scrolling_short';
 
 /**
+ * Annotations with LLM assistance
+ * @link https://app.launchdarkly.com/default/production/features/fflag_feat_all_lsdv_e_294_llm_annotations_180723_long
+ */
+export const FF_LLM_EPIC = 'fflag_feat_all_lsdv_e_294_llm_annotations_180723_long';
+
+/**
  * Fix logic of namespaces inside Hotkeys
  * @link https://app.launchdarkly.com/default/production/features/fflag_fix_font_lsdv_1148_hotkeys_namespaces_01022023_short
  */


### PR DESCRIPTION
This feature may be disabled in future.
And it definitely stops us from using very dynamic ML responses. For example choices may have problems with manual accept.

### PR fulfills these requirements
- [x] Commit message(s) and PR title follows the format `[fix|feat|ci|chore|doc]: TICKET-ID: Short description of change made` ex. `fix: DEV-XXXX: Removed inconsistent code usage causing intermittent errors`
- [ ] Tests for the changes have been added/updated (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Best efforts were made to ensure docs/code are concise and coherent (checked for spelling/grammatical errors, commented out code, debug logs etc.)
- [ ] Self-reviewed and ran all changes on a local instance (for bug fixes/features)



#### Change has impacts in these area(s)
_(check all that apply)_
- [ ] Product design
- [ ] Frontend



### Describe the reason for change
Choices not always appears after manual accept



#### What does this fix?
Auto accept any ML backend response with FF on



#### What libraries were added/updated?
none



#### Does this change affect performance?
nope



#### Does this change affect security?
nope



#### What alternative approaches were there?
fix desired tags ad-hoc, but that's harder and makes less sense.



#### What feature flags were used to cover this change?
`fflag_feat_all_lsdv_e_294_llm_annotations_180723_long`



### Does this PR introduce a breaking change?
_(check only one)_
- [x] Yes, and covered entirely by feature flag(s)
- [ ] Yes, and covered partially by feature flag(s)
- [ ] No
- [ ] Not sure (briefly explain the situation below)



### What level of testing was included in the change?
_(check all that apply)_
- [ ] e2e
- [ ] integration
- [ ] unit



### Which logical domain(s) does this change affect?
LLM, textarea, choices
